### PR TITLE
Change OTP code parameter name

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
@@ -45,7 +45,7 @@ public class SMSOTPConstants {
     public static final String SMS_OTP_ALPHA_NUMERIC_CHAR_SET = "KIGXHOYSPRWCEFMVUQLZDNABJT9245378016";
     public static final String MOBILE_NUMBER_MASKING_CHARACTER = "*";
     public static final String RESEND = "resendCode";
-    public static final String CODE = "OTPCode";
+    public static final String CODE = "OTPcode";
     public static final String OTP_TOKEN = "otpToken";
     public static final String OTP_EXPIRED = "isOTPExpired";
     public static final String OTP_GENERATED_TIME = "tokenGeneratedTime";


### PR DESCRIPTION
The OTP code parameter name is changed with the fix https://github.com/wso2/identity-apps/pull/4370. Therefore this PR changes the OTP code param name from `OTPCode` to `OTPcode`.

Related issue: https://github.com/wso2/product-is/issues/16701