### PR TITLE
Set missing display name property to Auth Initiation Data

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
@@ -692,6 +692,7 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
 
         AuthenticatorData authenticatorData = new AuthenticatorData();
         authenticatorData.setName(getName());
+        authenticatorData.setDisplayName(getFriendlyName());
         String idpName = null;
 
         AuthenticatedUser authenticatedUser = null;

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
@@ -184,6 +184,8 @@ public class SMSOTPAuthenticatorTest {
 
         Assert.assertEquals(authenticatorDataObj.getName(), SMSOTPConstants.SMS_OTP_AUTHENTICATOR_NAME,
                 "Authenticator name should match.");
+        Assert.assertEquals(authenticatorDataObj.getDisplayName(), SMSOTPConstants.SMS_OTP_AUTHENTICATOR_FRIENDLY_NAME,
+                "Authenticator display name should match.");
         Assert.assertEquals(authenticatorDataObj.getAuthParams().size(), authenticatorParamMetadataList.size(),
                 "Size of lists should be equal.");
         Assert.assertEquals(authenticatorDataObj.getPromptType(),


### PR DESCRIPTION
Fixes the issue of not having the display name property in the auth initiation data during api based authentication.

Related issue: https://github.com/wso2/product-is/issues/20219