### PR TITLE
Add otpTokenString parameter to SMSNotificationHandler

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
@@ -31,6 +31,7 @@ public class SMSNotificationConstants {
     public static final String SMS_PUBLISHER_NAME = "SMSPublisher";
     public static final String EVENT_NAME = "TRIGGER_SMS_NOTIFICATION_LOCAL";
     public static final String OTP_TOKEN_PROPERTY_NAME = "otpToken";
+    public static final String OTP_TOKEN_STRING_PROPERTY_NAME = "otpTokenString";
 
     public static final String ERROR_CODE_MISSING_SMS_SENDER = "40001";
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
@@ -113,8 +113,13 @@ public class SMSNotificationHandler extends DefaultNotificationHandler {
 
         SMSData smsData = new SMSData();
 
-        OTP otp = (OTP) eventProperties.get(SMSNotificationConstants.OTP_TOKEN_PROPERTY_NAME);
-        smsData.setBody(otp.getValue());
+        String otpString = (String) eventProperties.get(SMSNotificationConstants.OTP_TOKEN_STRING_PROPERTY_NAME);
+        if (StringUtils.isNotBlank(otpString)) {
+            smsData.setBody(otpString);
+        } else {
+            OTP otp = (OTP) eventProperties.get(SMSNotificationConstants.OTP_TOKEN_PROPERTY_NAME);
+            smsData.setBody(otp.getValue());
+        }
         smsData.setToNumber((String) eventProperties.get(SMSNotificationConstants.SMS_MASSAGE_TO_NAME));
 
         return smsData;


### PR DESCRIPTION
## Purpose
> SMSNotificationHandler currently accepts an org.wso2.carbon.identity.auth.otp.core.model.OTP object as the parameter to resolve the OPT code which is to be used with the sms template. However, in password recovery flow, the notification event is triggered through the governance component. Using this OTP class inside governance repository creates a circular dependency.  
This PR adds otpTokenString as an additional parameter to the SMSNotificationHandler to accept the OTP code through a string parameter. Since notification handler only uses the OTP code from the OTP object, no values are lost by using a String parameter.

## Related Issues
- https://github.com/wso2-enterprise/iam-engineering/issues/534
- https://github.com/wso2-enterprise/asgardeo-product/issues/25335

## Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/837
- https://github.com/wso2-extensions/identity-governance/pull/835