### PR TITLE
Fix sms templates not being applied

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/pom.xml
@@ -58,6 +58,10 @@
             <groupId>org.wso2.carbon.identity.auth.otp.commons</groupId>
             <artifactId>org.wso2.carbon.identity.auth.otp.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
@@ -70,6 +74,10 @@
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.user.api</artifactId>
         </dependency>
     </dependencies>
 
@@ -108,6 +116,10 @@
                             org.wso2.carbon.identity.local.auth.smsotp.provider; version="${project.version}",
                             org.wso2.carbon.identity.local.auth.smsotp.provider.exception; version="${project.version}",
                             org.wso2.carbon.identity.local.auth.smsotp.provider.model; version="${project.version}",
+                            org.wso2.carbon.identity.governance.*; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.*; version="${identity.organization.management.core.version.range}",
+                            org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.api.*; version="${carbon.user.api.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/pom.xml
@@ -62,6 +62,10 @@
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.user.api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
@@ -74,10 +78,6 @@
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.user.api</artifactId>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification;
 
+import java.util.Set;
+
 /**
  * Keep constants required by the SMS OTP Notification Event Handler.
  */
@@ -32,6 +34,29 @@ public class SMSNotificationConstants {
     public static final String EVENT_NAME = "TRIGGER_SMS_NOTIFICATION_LOCAL";
     public static final String OTP_TOKEN_PROPERTY_NAME = "otpToken";
     public static final String OTP_TOKEN_STRING_PROPERTY_NAME = "otpTokenString";
+    public static final String BODY_TEMPLATE = "body-template";
+    public static final String PROPERTY_APPLY_SMS_TEMPLATES = "NotificationTemplates.SMSTemplates.Apply";
+
+    public static final String PLACE_HOLDER_REGEX = "\\{\\{([a-zA-Z0-9\\-]+?)}}";
+    public static final String PLACE_HOLDER_CONFIRMATION_CODE = "confirmation-code";
+    public static final String PLACE_HOLDER_OTP_EXPIRY_TIME = "otp-expiry-time";
+    public static final String PLACE_HOLDER_TENANT_DOMAIN = "tenant-domain";
+    public static final String PLACE_HOLDER_USER_NAME = "user-name";
+    public static final String PLACE_HOLDER_USER_STORE_DOMAIN = "userstore-domain";
+    public static final String PLACEHOLDER_ORGANIZATION_NAME = "organization-name";
+    public static final String PLACE_HOLDER_APPLICATION_NAME = "application-name";
 
     public static final String ERROR_CODE_MISSING_SMS_SENDER = "40001";
+    public static final String ERROR_CODE_TEMPLATE_NOT_FOUND = "40002";
+
+    public static final String ERROR_MESSAGE_TEMPLATE_NOT_FOUND = "SMS template not found.";
+
+    public static final Set<String> ACCEPTED_SMS_PLACEHOLDERS = Set.of(
+            PLACE_HOLDER_TENANT_DOMAIN,
+            PLACE_HOLDER_USER_NAME,
+            PLACE_HOLDER_USER_STORE_DOMAIN,
+            PLACEHOLDER_ORGANIZATION_NAME,
+            PLACE_HOLDER_APPLICATION_NAME,
+            PLACE_HOLDER_CONFIRMATION_CODE,
+            PLACE_HOLDER_OTP_EXPIRY_TIME);
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
@@ -37,7 +37,7 @@ public class SMSNotificationConstants {
     public static final String BODY_TEMPLATE = "body-template";
     public static final String PROPERTY_APPLY_SMS_TEMPLATES = "NotificationTemplates.SMSTemplates.Apply";
 
-    public static final String PLACE_HOLDER_REGEX = "\\{\\{([a-zA-Z0-9\\-]+?)}}";
+    public static final String PLACE_HOLDER_REGEX = "\\{\\{([a-zA-Z0-9\\-]+?)\\}\\}";
     public static final String PLACE_HOLDER_CONFIRMATION_CODE = "confirmation-code";
     public static final String PLACE_HOLDER_OTP_EXPIRY_TIME = "otp-expiry-time";
     public static final String PLACE_HOLDER_TENANT_DOMAIN = "tenant-domain";

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationHandlerDataHolder.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationHandlerDataHolder.java
@@ -19,8 +19,11 @@
 package org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.internal;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.Provider;
 import org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementService;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +36,10 @@ public class SMSNotificationHandlerDataHolder {
 
     private static final SMSNotificationHandlerDataHolder instance = new SMSNotificationHandlerDataHolder();
 
+    private NotificationTemplateManager notificationTemplateManager;
     private NotificationSenderManagementService notificationSenderManagementService;
+    private OrganizationManager organizationManager;
+    private RealmService realmService;
     private final Map<String, Provider> providers = new HashMap<>();
 
     private SMSNotificationHandlerDataHolder() {
@@ -62,5 +68,33 @@ public class SMSNotificationHandlerDataHolder {
     public void setNotificationSenderManagementService(
             NotificationSenderManagementService notificationSenderManagementService) {
         this.notificationSenderManagementService = notificationSenderManagementService;
+    }
+
+    public void setNotificationTemplateManager(NotificationTemplateManager notificationTemplateManager) {
+
+        this.notificationTemplateManager = notificationTemplateManager;
+    }
+
+    public NotificationTemplateManager getNotificationTemplateManager() {
+
+        return notificationTemplateManager;
+    }
+
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
+    }
+
+    public RealmService getRealmService() {
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+        this.realmService = realmService;
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationHandlerDataHolder.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationHandlerDataHolder.java
@@ -91,10 +91,12 @@ public class SMSNotificationHandlerDataHolder {
     }
 
     public RealmService getRealmService() {
+
         return realmService;
     }
 
     public void setRealmService(RealmService realmService) {
+
         this.realmService = realmService;
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationHandlerServiceComponent.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationHandlerServiceComponent.java
@@ -28,9 +28,12 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
 import org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.SMSNotificationHandler;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.Provider;
 import org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementService;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.user.core.service.RealmService;
 
 /**
  * SMS Notification Handler service component.
@@ -103,5 +106,57 @@ public class SMSNotificationHandlerServiceComponent {
     protected void unsetProvider(Provider provider) {
 
         SMSNotificationHandlerDataHolder.getInstance().removeProvider(provider.getName());
+    }
+
+    @Reference(name = "notificationTemplateManager.service",
+            service = org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetNotificationTemplateManager")
+    protected void setNotificationTemplateManager(NotificationTemplateManager notificationTemplateManager) {
+
+        LOG.debug("Setting the Notification Template Manager");
+        SMSNotificationHandlerDataHolder.getInstance().setNotificationTemplateManager(notificationTemplateManager);
+    }
+
+    protected void unsetNotificationTemplateManager(NotificationTemplateManager notificationTemplateManager) {
+
+        LOG.debug("UnSetting the Notification Email Template Manager");
+        SMSNotificationHandlerDataHolder.getInstance().setNotificationTemplateManager(null);
+    }
+
+    @Reference(name = "identity.organization.management.component",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        LOG.debug("Setting the Organization Manager");
+        SMSNotificationHandlerDataHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        LOG.debug("UnSetting the Organization Manager");
+        SMSNotificationHandlerDataHolder.getInstance().setOrganizationManager(null);
+    }
+
+    @Reference(
+            name = "realm.service",
+            service = org.wso2.carbon.user.core.service.RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService")
+    protected void setRealmService(RealmService realmService) {
+
+        LOG.debug("Setting the Realm Service");
+        SMSNotificationHandlerDataHolder.getInstance().setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        LOG.debug("UnSetting the Realm Service");
+        SMSNotificationHandlerDataHolder.getInstance().setRealmService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationUtil.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationUtil.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.internal;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.auth.otp.core.model.OTP;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.SMSNotificationConstants;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.SMSNotificationConstants.ACCEPTED_SMS_PLACEHOLDERS;
+import static org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.SMSNotificationConstants.OTP_TOKEN_STRING_PROPERTY_NAME;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT;
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
+/**
+ * Utility class for SMS notifications.
+ */
+public class SMSNotificationUtil {
+
+    /**
+     * Replace placeholders in the SMS template with the values in the valuesMap.
+     *
+     * @param template          SMS template.
+     * @param notificationData  All resolved notification data.
+     * @return SMS body with placeholders replaced with values.
+     */
+    public static String replacePlaceholders(String template, Map<String, String> notificationData) {
+
+        Map<String, String> filteredPlaceholderData = filterPlaceHolderData(notificationData);
+        // Regular expression to match placeholders in the format {{placeholder-name}}
+        Matcher placeHolderMatcher = Pattern.compile(SMSNotificationConstants.PLACE_HOLDER_REGEX).matcher(template);
+        StringBuilder smsBody = new StringBuilder();
+        while (placeHolderMatcher.find()) {
+            String placeholder = placeHolderMatcher.group(1);
+            String replacement = filteredPlaceholderData.get(placeholder);
+            if (StringUtils.isBlank(replacement)) {
+                continue;
+            }
+            placeHolderMatcher.appendReplacement(smsBody, Matcher.quoteReplacement(replacement));
+        }
+        placeHolderMatcher.appendTail(smsBody);
+        return smsBody.toString();
+    }
+
+    /**
+     * Resolve OTP values in the event properties and add them to the notification data.
+     *
+     * @param dataMap Notification data.
+     */
+    public static void resolveOTPValues(Map<String, Object> dataMap, Map<String, String> notificationData) {
+
+        OTP otp = (OTP) dataMap.get(SMSNotificationConstants.OTP_TOKEN_PROPERTY_NAME);
+        if (otp != null) {
+            notificationData.put(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE, otp.getValue());
+            notificationData.put(SMSNotificationConstants.PLACE_HOLDER_OTP_EXPIRY_TIME,
+                    String.valueOf(TimeUnit.MILLISECONDS.toMinutes(otp.getValidityPeriodInMillis())));
+        } else {
+            String otpCode = (String) dataMap.get(OTP_TOKEN_STRING_PROPERTY_NAME);
+            if (StringUtils.isNotBlank(otpCode)) {
+                notificationData.put(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE, otpCode);
+            }
+        }
+    }
+
+    /**
+     * Get if applying SMS templates is enabled.
+     *
+     * @return boolean if applying SMS templates is enabled.
+     */
+    public static boolean isEnabledSMSTemplates() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(SMSNotificationConstants.PROPERTY_APPLY_SMS_TEMPLATES));
+    }
+
+    /**
+     * Filter out the placeholders that are not accepted in the SMS template.
+     *
+     * @param notificationData Notification data.
+     * @return Filtered notification data.
+     */
+    public static Map<String, String> filterPlaceHolderData(Map<String, String> notificationData) {
+
+        Map<String, String> result = new HashMap<>();
+        for (Map.Entry<String, String> entry : notificationData.entrySet()) {
+            if (ACCEPTED_SMS_PLACEHOLDERS.contains(entry.getKey())) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * If the tenant domain is a UUID, resolve the organization name from the associated organization resource.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return Human-readable name related to the represented organization space.
+     * @throws IdentityEventException Error while resolving organization name.
+     */
+    public static String resolveHumanReadableOrganizationName(String tenantDomain) throws IdentityEventException {
+
+        String organizationName = tenantDomain;
+        try {
+            if (SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+                return organizationName;
+            }
+            RealmService realmService = SMSNotificationHandlerDataHolder.getInstance().getRealmService();
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            Tenant tenant = realmService.getTenantManager().getTenant(tenantId);
+            if (tenant == null) {
+                return organizationName;
+            }
+            String associatedOrganizationUUID = tenant.getAssociatedOrganizationUUID();
+            if (StringUtils.isBlank(associatedOrganizationUUID)) {
+                return organizationName;
+            }
+            OrganizationManager organizationManager =
+                    SMSNotificationHandlerDataHolder.getInstance().getOrganizationManager();
+            organizationName = organizationManager.getOrganizationNameById(associatedOrganizationUUID);
+        } catch (OrganizationManagementClientException e) {
+            if (!ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT.getCode().equals(e.getErrorCode())) {
+                throw new IdentityEventException(e.getMessage(), e);
+            }
+        } catch (OrganizationManagementException | UserStoreException e) {
+            throw new IdentityEventException(e.getMessage(), e);
+        }
+        return organizationName;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationUtilTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationUtilTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.auth.otp.core.model.OTP;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.internal.SMSNotificationHandlerDataHolder;
+import org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.internal.SMSNotificationUtil;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SMSNotificationUtil}.
+ */
+public class SMSNotificationUtilTest {
+
+    @Mock
+    private RealmService mockedRealmService;
+
+    @Mock
+    private TenantManager mockedTenantManager;
+
+    @Mock
+    private OrganizationManager mockedOrganizationManager;
+
+    private MockedStatic<IdentityTenantUtil> mockedStaticIdentityTenantUtil;
+
+    private static final String SUPER_TENANT_DOMAIN = "carbon.super";
+    private static final String TEST_TENANT_DOMAIN = "test.tenant";
+    private static final String TEST_ORG_NAME = "testOrg";
+    private static final String TEST_ORG_UUID = "12312434";
+
+    @BeforeClass
+    public void beforeTest() {
+
+        mockIdentityTenantUtil();
+    }
+
+    @BeforeTest
+    public void setUp() {
+
+        MockitoAnnotations.openMocks(this);
+        SMSNotificationHandlerDataHolder
+                .getInstance()
+                .setRealmService(mockedRealmService);
+        SMSNotificationHandlerDataHolder
+                .getInstance()
+                .setOrganizationManager(mockedOrganizationManager);
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        mockedStaticIdentityTenantUtil.close();
+    }
+
+    @DataProvider(name = "otpDataProvider")
+    public Object[][] otpDataProvider() {
+
+        return new Object[][] {
+                {
+                    new HashMap<String, Object>() {
+                        {
+                            put(SMSNotificationConstants.OTP_TOKEN_PROPERTY_NAME, new OTP("123456", 300000, 300000));
+                        }
+                    }, new HashMap<String, String>(), "123456", "5"
+                },
+                {
+                    new HashMap<String, String>() {
+                        {
+                            put(SMSNotificationConstants.OTP_TOKEN_STRING_PROPERTY_NAME, "123456");
+                        }
+                    }, new HashMap<String, String>(), "123456", null
+                }
+        };
+    }
+
+    @DataProvider(name = "placeholderDataProvider")
+    public Object[][] placeholderDataProvider() {
+
+        String testSMSTemplate =
+                "Your confirmation code is {{confirmation-code}}. It will expire in {{otp-expiry-time}} minutes.";
+        return new Object[][] {
+                { testSMSTemplate, new HashMap<>(), testSMSTemplate },
+                { testSMSTemplate, new HashMap<String, String>() {
+                        {
+                            put(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE, "123456");
+                            put(SMSNotificationConstants.PLACE_HOLDER_OTP_EXPIRY_TIME, "5");
+                        }
+                    }, "Your confirmation code is 123456. It will expire in 5 minutes."
+                }
+        };
+    }
+
+    @DataProvider(name = "filterPlaceholderDataProvider")
+    public Object[][] filterPlaceholderDataProvider() {
+
+        return new Object[][] {
+                { new HashMap<>(), new HashMap<>() },
+                {
+                    new HashMap<String, String>() {
+                        {
+                            put(SMSNotificationConstants.PLACE_HOLDER_TENANT_DOMAIN, "tenant");
+                            put(SMSNotificationConstants.PLACE_HOLDER_USER_NAME, "user");
+                            put(SMSNotificationConstants.PLACE_HOLDER_USER_STORE_DOMAIN, "userstore");
+                            put(SMSNotificationConstants.PLACEHOLDER_ORGANIZATION_NAME, "org");
+                            put(SMSNotificationConstants.PLACE_HOLDER_APPLICATION_NAME, "app");
+                            put(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE, "1234");
+                            put(SMSNotificationConstants.PLACE_HOLDER_OTP_EXPIRY_TIME, "300000");
+                            put("InvalidPlaceHolderName1", "value1");
+                            put("InvalidPlaceHolderName2", "value2");
+                        }
+                    },
+                    new HashMap<String, String>() {
+                        {
+                            put(SMSNotificationConstants.PLACE_HOLDER_TENANT_DOMAIN, "tenant");
+                            put(SMSNotificationConstants.PLACE_HOLDER_USER_NAME, "user");
+                            put(SMSNotificationConstants.PLACE_HOLDER_USER_STORE_DOMAIN, "userstore");
+                            put(SMSNotificationConstants.PLACEHOLDER_ORGANIZATION_NAME, "org");
+                            put(SMSNotificationConstants.PLACE_HOLDER_APPLICATION_NAME, "app");
+                            put(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE, "1234");
+                            put(SMSNotificationConstants.PLACE_HOLDER_OTP_EXPIRY_TIME, "300000");
+                        }
+                    }
+                }
+        };
+    }
+
+    @DataProvider(name = "organizationNameDataProvider")
+    public Object[][] organizationNameDataProvider() {
+
+        Tenant testTenant1 = new Tenant();
+        Tenant testTenant2 = new Tenant();
+        testTenant2.setAssociatedOrganizationUUID(TEST_ORG_UUID);
+        return new Object[][] {
+                { SUPER_TENANT_DOMAIN, SUPER_TENANT_DOMAIN, null },
+                { TEST_TENANT_DOMAIN, TEST_TENANT_DOMAIN, null },
+                { TEST_TENANT_DOMAIN, TEST_TENANT_DOMAIN, testTenant1 },
+                { TEST_TENANT_DOMAIN, TEST_ORG_NAME, testTenant2 }
+        };
+    }
+
+    @Test(dataProvider = "placeholderDataProvider")
+    public void testReplacePlaceholders(String template, Map<String, String> notificationData, String expectedSMSBody) {
+
+        String smsBody = SMSNotificationUtil.replacePlaceholders(template, notificationData);
+        Assert.assertEquals(smsBody, expectedSMSBody);
+    }
+
+    @Test(dataProvider = "otpDataProvider")
+    public void testResolveOTPValuesWithOTPObject(Map<String, Object> dataMap, Map<String, String> notificationData,
+                                                  String confirmationCode, String expiryTime) {
+
+        SMSNotificationUtil.resolveOTPValues(dataMap, notificationData);
+        Assert.assertEquals(
+                notificationData.get(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE), confirmationCode);
+        Assert.assertEquals(notificationData.get(SMSNotificationConstants.PLACE_HOLDER_OTP_EXPIRY_TIME), expiryTime);
+    }
+
+    @Test
+    public void testIsEnabledSMSTemplates() {
+
+        try (MockedStatic<IdentityUtil> mockedIdentityUtil = mockStatic(IdentityUtil.class)) {
+            mockedIdentityUtil.when(() ->
+                            IdentityUtil.getProperty(SMSNotificationConstants.PROPERTY_APPLY_SMS_TEMPLATES))
+                    .thenReturn("true");
+            Assert.assertTrue(SMSNotificationUtil.isEnabledSMSTemplates());
+        }
+    }
+
+    @Test(dataProvider = "filterPlaceholderDataProvider")
+    public void testFilterPlaceHolderData(Map<String, String> notificationDataInput,
+                                          Map<String, String> expectedOutput) {
+
+        Map<String, String> filteredData = SMSNotificationUtil.filterPlaceHolderData(notificationDataInput);
+        Assert.assertEquals(filteredData, expectedOutput);
+    }
+
+    @Test(dataProvider = "organizationNameDataProvider")
+    public void  testResolveHumanReadableOrganizationName(String tenant, String expectedOrgName, Tenant testTenant)
+            throws IdentityEventException, UserStoreException, OrganizationManagementException {
+
+        when(mockedRealmService.getTenantManager()).thenReturn(mockedTenantManager);
+        when(mockedTenantManager.getTenant(anyInt())).thenReturn(testTenant);
+        when(mockedOrganizationManager.getOrganizationNameById(TEST_ORG_UUID)).thenReturn(TEST_ORG_NAME);
+        String orgName = SMSNotificationUtil.resolveHumanReadableOrganizationName(tenant);
+        Assert.assertEquals(orgName, expectedOrgName);
+    }
+
+    private void mockIdentityTenantUtil() {
+
+        mockedStaticIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(SUPER_TENANT_DOMAIN)).thenReturn(1);
+        when(IdentityTenantUtil.getTenantId(TEST_TENANT_DOMAIN)).thenReturn(2);
+    }
+}

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/TestableSMSNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/TestableSMSNotificationHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification;
+
+import org.wso2.carbon.identity.event.event.Event;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestableSMSNotificationHandler extends SMSNotificationHandler {
+
+    public static Map<String, String> notificationData;
+
+    static {
+        resetNotificationData();
+    }
+
+    public static void resetNotificationData() {
+
+        notificationData = new HashMap<>();
+        notificationData.put("send-to", "+11110000");
+        notificationData.put("TEMPLATE_TYPE", "SMSOTP");
+        notificationData.put("application-name", "sms_otp_singlepage_App");
+        notificationData.put("notification-channel", "smsotp");
+        notificationData.put("notification-event", "smsotp");
+        notificationData.put("mobile", "+11110000");
+        notificationData.put("otpToken", "874090");
+        notificationData.put("userstore-domain", "DEFAULT");
+        notificationData.put("locale", "en_US");
+        notificationData.put("body", "Your one-time password for the sms_otp_singlepage_App is 874090. " +
+                "This expires in 5 minutes.");
+        notificationData.put("tenant-domain", "tenant1");
+        notificationData.put("otp-expiry-time", "5");
+        notificationData.put("user-name", "wso2@gmail.com");
+        notificationData.put("body-template", "Your one-time password for the {{application-name}} " +
+                "is {{otpToken}}. This expires in {{otp-expiry-time}} minutes.,");
+    }
+
+    protected void publishToStream(Map<String, String> dataMap, Event event) {
+
+    }
+
+    protected Map<String, String> buildNotificationData(Event event) {
+
+        return notificationData;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,13 @@
         <carbon.kernel.version>4.9.16</carbon.kernel.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <carbon.identity.framework.version>5.25.522</carbon.identity.framework.version>
-        <identity.governance.version>1.8.40</identity.governance.version>
+        <identity.governance.version>1.11.11</identity.governance.version>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <carbon.identity.account.lock.handler.version>1.8.2</carbon.identity.account.lock.handler.version>
         <identity.auth.otp.commons.version>1.0.3</identity.auth.otp.commons.version>
         <identity.event.handler.notification.version>1.7.17</identity.event.handler.notification.version>
         <identity.notification.sender.tenant.config.version>1.7.10</identity.notification.sender.tenant.config.version>
+        <identity.organization.management.core.version>1.0.93</identity.organization.management.core.version>
 
         <findsecbugs-plugin.version>1.10.1</findsecbugs-plugin.version>
 
@@ -89,6 +90,8 @@
         <identity.event.handler.notification.imp.pkg.version.range>[1.3.15, 2.0.0)
         </identity.event.handler.notification.imp.pkg.version.range>
         <identity.auth.otp.commons.version.range>[1.0.0, 2.0.0)</identity.auth.otp.commons.version.range>
+        <identity.organization.management.core.version.range>[1.0.0, 2.0.0)
+        </identity.organization.management.core.version.range>
 
         <maven.checkstyleplugin.version>3.1.0</maven.checkstyleplugin.version>
         <findsecbugs-plugin.version>1.10.1</findsecbugs-plugin.version>
@@ -171,6 +174,12 @@
                 <groupId>org.wso2.carbon.identity.auth.otp.commons</groupId>
                 <artifactId>org.wso2.carbon.identity.auth.otp.core</artifactId>
                 <version>${identity.auth.otp.commons.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${identity.organization.management.core.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Purpose
> Currently the SMSNotificationHandler does not apply any SMS templates for the notifications being published.
> This PR adds the functionality of applying the SMS notification templates for the SMSNotificationHandler. 

## Related Issue
- https://github.com/wso2/product-is/issues/21620

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6104
- https://github.com/wso2-extensions/identity-event-handler-notification/pull/273

## When to merge
After : 
- https://github.com/wso2/carbon-identity-framework/pull/6104 

## Unit test coverage 
- Unit tests are added to cover all introduced code changes.
