### PR TITLE
Fixing javadoc issues in maven release build 

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/util/AuthenticatorUtils.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/util/AuthenticatorUtils.java
@@ -132,6 +132,7 @@ public class AuthenticatorUtils {
      * Get the multi option URI query params.
      *
      * @param request HttpServletRequest.
+     * @return Multi option URI query parameter value.
      */
     public static String getMultiOptionURIQueryParam(HttpServletRequest request) {
 


### PR DESCRIPTION
## Purpose
> After bumping the JDK version for the jenkins build to JDK 11, release build is failing due to java doc issue.
> This PR fixes the error `warning: no @return` being thrown by javadoc build during release build process.

## Related Issue 
- https://github.com/wso2/product-is/issues/21656