### PR TITLE
Fixing javadoc issues in maven release build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,21 @@
                         </instructions>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <source>1.8</source>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
## Purpose
> Define javadoc plugin with java 1.8 as source to be preserve backward compatibility.

## Related Issues 
- https://github.com/wso2/product-is/issues/21656