### PR TITLE
Overidden the useOnlyNumericChars in SMSOTPAuthenticator

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
@@ -724,4 +724,16 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
         authenticatorData.setAuthParams(authenticatorParamMetadataList);
         return Optional.of(authenticatorData);
     }
+
+    @Override
+    protected boolean useOnlyNumericChars(String tenantDomain) throws AuthenticationFailedException {
+
+        try {
+            return Boolean.parseBoolean(AuthenticatorUtils.getSmsAuthenticatorConfig
+                    (SMSOTPConstants.ConnectorConfig.SMS_OTP_USE_NUMERIC_CHARS, tenantDomain));
+        } catch (SMSOTPAuthenticatorServerException exception) {
+            throw handleAuthErrorScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_CONFIG);
+        }
+    }
+
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
@@ -19,9 +19,11 @@
 package org.wso2.carbon.identity.local.auth.smsotp.authenticator;
 
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
@@ -30,6 +32,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.auth.otp.core.constant.AuthenticatorConstants;
 import org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants;
+import org.wso2.carbon.identity.local.auth.smsotp.authenticator.util.AuthenticatorUtils;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -202,6 +205,29 @@ public class SMSOTPAuthenticatorTest {
                     "Parameter order should match.");
             Assert.assertEquals(actualParam.isConfidential(), expectedParam.isConfidential(),
                     "Parameter mandatory status should match.");
+        }
+    }
+
+    @DataProvider
+    public static Object[][] validateTestUseOnlyNumbersInOTP() {
+        return new Object[][] {
+                {"carbon.super", "true"},
+                {"carbon.super", "false"},
+        };
+    }
+
+    @Test(dataProvider = "validateTestUseOnlyNumbersInOTP")
+    public void testUseOnlyNumbersInOTP(String tenantDomain, String useNumericChars) {
+        try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
+            mockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
+                            SMSOTPConstants.ConnectorConfig.SMS_OTP_USE_NUMERIC_CHARS, tenantDomain))
+                    .thenReturn(useNumericChars);
+
+            boolean useOnlyNumbersInOTP = smsotpAuthenticator.useOnlyNumericChars(tenantDomain);
+            assertEquals(useOnlyNumbersInOTP, Boolean.parseBoolean(useNumericChars));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+
         }
     }
 }


### PR DESCRIPTION
## Purpose
There was a bug in SMS OTP Connection where even when "Use only numeric characters OTP" is not checked only numeric values contained in OTP.

## Goals
To return alphanumeric values when requires in SMS OTP

## Approach
Overidden the useOnlyNumericChars in AbstractOTPAuthenticator class to SMSOTPAuthenticator class and changed the implementation to return values appropriately. 


## Documentation
Issue ##19839 (https://github.com/wso2/product-is/issues/19839)


## Automation tests
 - Unit tests 
  Implemented a unit test to check logic of useOnlyNumericChars method


## Test environment
JDK 11, Windows 11, Carbon H2 Database
 
