### PR TITLE
Remove notification_templates.sms_templates.apply config

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
@@ -35,7 +35,6 @@ public class SMSNotificationConstants {
     public static final String OTP_TOKEN_PROPERTY_NAME = "otpToken";
     public static final String OTP_TOKEN_STRING_PROPERTY_NAME = "otpTokenString";
     public static final String BODY_TEMPLATE = "body-template";
-    public static final String PROPERTY_APPLY_SMS_TEMPLATES = "NotificationTemplates.SMSTemplates.Apply";
 
     public static final String PLACE_HOLDER_REGEX = "\\{\\{([a-zA-Z0-9\\-]+?)\\}\\}";
     public static final String PLACE_HOLDER_CONFIRMATION_CODE = "confirmation-code";

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.auth.otp.core.model.OTP;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.event.IdentityEventException;
@@ -114,17 +113,7 @@ public class SMSNotificationHandler extends DefaultNotificationHandler {
 
         SMSData smsData = new SMSData();
         Map<String, Object> eventProperties = event.getEventProperties();
-        if (SMSNotificationUtil.isEnabledSMSTemplates()) {
-            smsData.setBody(constructTemplatedSMSBody(event));
-        } else {
-            String otpString = (String) eventProperties.get(SMSNotificationConstants.OTP_TOKEN_STRING_PROPERTY_NAME);
-            if (StringUtils.isNotBlank(otpString)) {
-                smsData.setBody(otpString);
-            } else {
-                OTP otp = (OTP) eventProperties.get(SMSNotificationConstants.OTP_TOKEN_PROPERTY_NAME);
-                smsData.setBody(otp.getValue());
-            }
-        }
+        smsData.setBody(constructTemplatedSMSBody(event));
         smsData.setToNumber((String) eventProperties.get(SMSNotificationConstants.SMS_MASSAGE_TO_NAME));
         return smsData;
     }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationUtil.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationUtil.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.in
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.auth.otp.core.model.OTP;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.SMSNotificationConstants;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
@@ -90,16 +89,6 @@ public class SMSNotificationUtil {
                 notificationData.put(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE, otpCode);
             }
         }
-    }
-
-    /**
-     * Get if applying SMS templates is enabled.
-     *
-     * @return boolean if applying SMS templates is enabled.
-     */
-    public static boolean isEnabledSMSTemplates() {
-
-        return Boolean.parseBoolean(IdentityUtil.getProperty(SMSNotificationConstants.PROPERTY_APPLY_SMS_TEMPLATES));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandlerTest.java
@@ -109,7 +109,6 @@ public class SMSNotificationHandlerTest {
 
         Event testEvent = constructSMSOTPEvent();
         try (MockedStatic<SMSNotificationUtil> mockedSMSNotificationUtil = mockStatic(SMSNotificationUtil.class)) {
-            mockedSMSNotificationUtil.when(SMSNotificationUtil::isEnabledSMSTemplates).thenReturn(true);
             mockedSMSNotificationUtil.when(() -> SMSNotificationUtil.replacePlaceholders(
                     TestableSMSNotificationHandler.notificationData.get(SMSNotificationConstants.BODY_TEMPLATE),
                     TestableSMSNotificationHandler.notificationData)).thenReturn("success");
@@ -123,7 +122,6 @@ public class SMSNotificationHandlerTest {
 
         Event testEvent = constructSMSOTPEvent();
         try (MockedStatic<SMSNotificationUtil> mockedSMSNotificationUtil = mockStatic(SMSNotificationUtil.class)) {
-            mockedSMSNotificationUtil.when(SMSNotificationUtil::isEnabledSMSTemplates).thenReturn(true);
             mockedSMSNotificationUtil.when(() -> SMSNotificationUtil.replacePlaceholders(
                     TestableSMSNotificationHandler.notificationData.get(SMSNotificationConstants.BODY_TEMPLATE),
                     TestableSMSNotificationHandler.notificationData)).thenReturn("success");

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationUtilTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationUtilTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.auth.otp.core.model.OTP;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.internal.SMSNotificationHandlerDataHolder;
 import org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.internal.SMSNotificationUtil;
@@ -193,17 +192,6 @@ public class SMSNotificationUtilTest {
         Assert.assertEquals(
                 notificationData.get(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE), confirmationCode);
         Assert.assertEquals(notificationData.get(SMSNotificationConstants.PLACE_HOLDER_OTP_EXPIRY_TIME), expiryTime);
-    }
-
-    @Test
-    public void testIsEnabledSMSTemplates() {
-
-        try (MockedStatic<IdentityUtil> mockedIdentityUtil = mockStatic(IdentityUtil.class)) {
-            mockedIdentityUtil.when(() ->
-                            IdentityUtil.getProperty(SMSNotificationConstants.PROPERTY_APPLY_SMS_TEMPLATES))
-                    .thenReturn("true");
-            Assert.assertTrue(SMSNotificationUtil.isEnabledSMSTemplates());
-        }
     }
 
     @Test(dataProvider = "filterPlaceholderDataProvider")


### PR DESCRIPTION
## Purpose 
The config notification_templates.sms_templates.apply was added to disable a fix introduced for sms templates not being applied, if needed. This PR removes this config since the fix is deployed and verified, hence no need of the config any longer. 

## Related Issue 
- https://github.com/wso2-enterprise/asgardeo-product/issues/27279
- https://github.com/wso2-enterprise/asgardeo-product/issues/28756

## Fix applied demo

https://github.com/user-attachments/assets/7ca126ba-d671-44ec-9b7f-faea4679fad1

