### PR TITLE
Reset isRetrying property to properly handle the process SMS OTP flow

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
@@ -74,6 +74,8 @@ import static org.wso2.carbon.identity.configuration.mgt.core.constant.Configura
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.CODE;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.DISPLAY_CODE;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.DISPLAY_USERNAME;
+import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.RESEND;
+import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.SMS_OTP_AUTHENTICATOR_NAME;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.USERNAME;
 import static org.wso2.carbon.user.core.UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
 
@@ -96,7 +98,7 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
             LOG.debug("Inside SMSOTPAuthenticator canHandle method and check the existence of mobile number and " +
                     "otp code");
         }
-        return ((StringUtils.isNotEmpty(request.getParameter(SMSOTPConstants.RESEND))
+        return ((StringUtils.isNotEmpty(request.getParameter(RESEND))
                 && StringUtils.isEmpty(request.getParameter(CODE)))
                 || StringUtils.isNotEmpty(request.getParameter(CODE))
                 || StringUtils.isNotEmpty(request.getParameter(SMSOTPConstants.MOBILE_NUMBER))
@@ -120,6 +122,29 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
     public String getName() {
 
         return SMSOTPConstants.SMS_OTP_AUTHENTICATOR_NAME;
+    }
+
+    @Override
+    public AuthenticatorConstants.AuthenticationScenarios resolveScenario(HttpServletRequest request,
+            AuthenticationContext context) {
+
+        // If the current authenticator is not SMS OTP, then set the flow to not retrying which could have been
+        // set from other authenticators and not cleared.
+        if (!SMS_OTP_AUTHENTICATOR_NAME.equals(context.getCurrentAuthenticator())) {
+            context.setRetrying(false);
+        }
+        if (context.isLogoutRequest()) {
+            return AuthenticatorConstants.AuthenticationScenarios.LOGOUT;
+        } else if (!context.isRetrying() && StringUtils.isBlank(request.getParameter(CODE)) &&
+                !Boolean.parseBoolean(request.getParameter(RESEND))) {
+            return AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP;
+        } else {
+            return context.isRetrying() &&
+                    Boolean.parseBoolean(request.getParameter(RESEND)) &&
+                    Boolean.parseBoolean(request.getParameter(RESEND)) ?
+                    AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP :
+                    AuthenticatorConstants.AuthenticationScenarios.SUBMIT_OTP;
+        }
     }
 
     @Override
@@ -254,9 +279,9 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
             eventProperties.put(IdentityEventConstants.EventProperty.USER_ID, authenticatedUser.getUserId());
             eventProperties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN,
                     authenticatedUser.getUserStoreDomain());
-            if (StringUtils.isNotBlank(httpServletRequest.getParameter(SMSOTPConstants.RESEND))) {
+            if (StringUtils.isNotBlank(httpServletRequest.getParameter(RESEND))) {
                 eventProperties.put(IdentityEventConstants.EventProperty.RESEND_CODE,
-                        httpServletRequest.getParameter(SMSOTPConstants.RESEND));
+                        httpServletRequest.getParameter(RESEND));
             } else {
                 eventProperties.put(IdentityEventConstants.EventProperty.RESEND_CODE, false);
             }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
@@ -140,7 +140,6 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
             return AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP;
         } else {
             return context.isRetrying() &&
-                    Boolean.parseBoolean(request.getParameter(RESEND)) &&
                     Boolean.parseBoolean(request.getParameter(RESEND)) ?
                     AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP :
                     AuthenticatorConstants.AuthenticationScenarios.SUBMIT_OTP;

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
@@ -44,7 +44,9 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.CODE;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.DISPLAY_USERNAME;
+import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.RESEND;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.USERNAME;
 
 
@@ -66,7 +68,7 @@ public class SMSOTPAuthenticatorTest {
     @Test
     public void testCanHandle() {
 
-        when(httpServletRequest.getParameter(SMSOTPConstants.RESEND)).thenReturn("true");
+        when(httpServletRequest.getParameter(RESEND)).thenReturn("true");
         assertTrue(smsotpAuthenticator.canHandle(httpServletRequest));
     }
 
@@ -112,7 +114,34 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testResolveScenario() {
-        assertTrue(true, "Test case not implemented yet");
+
+        SMSOTPAuthenticator smsotpAuthenticator = new SMSOTPAuthenticator();
+        AuthenticationContext context = Mockito.mock(AuthenticationContext.class);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        // Test case 1: Logout request
+        when(context.isLogoutRequest()).thenReturn(true);
+        assertEquals(smsotpAuthenticator.resolveScenario(request, context),
+                AuthenticatorConstants.AuthenticationScenarios.LOGOUT);
+
+        // Test case 2: Initial OTP scenario
+        when(context.isLogoutRequest()).thenReturn(false);
+        when(context.isRetrying()).thenReturn(false);
+        when(request.getParameter(CODE)).thenReturn(null);
+        when(request.getParameter(RESEND)).thenReturn(String.valueOf(false));
+        assertEquals(smsotpAuthenticator.resolveScenario(request, context),
+                AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP);
+
+        // Test case 3: Resend OTP scenario
+        when(context.isRetrying()).thenReturn(true);
+        when(request.getParameter(RESEND)).thenReturn(String.valueOf(true));
+        assertEquals(smsotpAuthenticator.resolveScenario(request, context),
+                AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP);
+
+        // Test case 4: Submit OTP scenario
+        when(request.getParameter(RESEND)).thenReturn(String.valueOf(false));
+        assertEquals(smsotpAuthenticator.resolveScenario(request, context),
+                AuthenticatorConstants.AuthenticationScenarios.SUBMIT_OTP);
     }
 
     @Test


### PR DESCRIPTION
## Purpose
- `context.isRetrying()` is set to `true` from previous failed authenticator.
- If the current authenticator set in the context is different than SMS OTP, then context.isRetrying() can be reset considering this is the first time the authentication flow is entering email OTP authenticator.

## Implementation
This PR includes changes to the `SMSOTPAuthenticator` class to improve its functionality and add new features. 

#### Improvements to `SMSOTPAuthenticator` functionality:

* Modified the `canHandle` method to use the `RESEND` constant directly.
* Updated the `publishPostOTPGeneratedEvent` method to use the `RESEND` constant directly.

#### Enhancements to test coverage:

* Modified the `testCanHandle` method to use the `RESEND` constant directly.
* Implemented the `testResolveScenario` method to cover different scenarios such as logout, initial OTP, resend OTP, and submit OTP.

## Related Issues
- https://github.com/wso2/product-is/issues/21823