### PR TITLE
Fix resolving for wrong scenario when OTPcode is set from previous authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
@@ -135,7 +135,8 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
         }
         if (context.isLogoutRequest()) {
             return AuthenticatorConstants.AuthenticationScenarios.LOGOUT;
-        } else if (!context.isRetrying() && StringUtils.isBlank(request.getParameter(CODE)) &&
+        } else if (!SMS_OTP_AUTHENTICATOR_NAME.equals(context.getCurrentAuthenticator()) ||
+                !context.isRetrying() && StringUtils.isBlank(request.getParameter(CODE)) &&
                 !Boolean.parseBoolean(request.getParameter(RESEND))) {
             return AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP;
         } else {

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
@@ -63,6 +63,7 @@ import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.CODE;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.DISPLAY_USERNAME;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.RESEND;
+import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.SMS_OTP_AUTHENTICATOR_NAME;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.USERNAME;
 
 
@@ -150,6 +151,8 @@ public class SMSOTPAuthenticatorTest {
         assertEquals(smsotpAuthenticator.resolveScenario(request, context),
                 AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP);
 
+        when(context.getCurrentAuthenticator()).thenReturn(SMS_OTP_AUTHENTICATOR_NAME);
+
         // Test case 3: Resend OTP scenario
         when(context.isRetrying()).thenReturn(true);
         when(request.getParameter(RESEND)).thenReturn(String.valueOf(true));
@@ -160,6 +163,12 @@ public class SMSOTPAuthenticatorTest {
         when(request.getParameter(RESEND)).thenReturn(String.valueOf(false));
         assertEquals(smsotpAuthenticator.resolveScenario(request, context),
                 AuthenticatorConstants.AuthenticationScenarios.SUBMIT_OTP);
+
+        // Test case 5: Submit OTP scenario with OTP code
+        when(request.getParameter(CODE)).thenReturn("123456");
+        when(context.getCurrentAuthenticator()).thenReturn("dummyAuthenticator");
+        assertEquals(smsotpAuthenticator.resolveScenario(request, context),
+                AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP);
     }
 
     @Test


### PR DESCRIPTION
### Purpose
- Resolve the scenario properly when there is residual data available from Email OTP Authenticator
- `OTPcode` will be available in the request in the following scenario
  - if the previous step is Email OTP and the user is using app native authentication and has used the param name as `OTPcode` instead of `OTPCode`
- Revert https://github.com/wso2-extensions/identity-local-auth-emailotp/pull/46

### Related Issue
- https://github.com/wso2/product-is/issues/23543