### PR TITLE
Add support for templating current year

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
@@ -42,6 +42,7 @@ public class SMSNotificationConstants {
     public static final String PLACE_HOLDER_USER_STORE_DOMAIN = "userstore-domain";
     public static final String PLACEHOLDER_ORGANIZATION_NAME = "organization-name";
     public static final String PLACE_HOLDER_APPLICATION_NAME = "application-name";
+    public static final String PLACE_HOLDER_CURRENT_YEAR = "current-year";
 
     public static final String ERROR_CODE_MISSING_SMS_SENDER = "40001";
     public static final String ERROR_CODE_TEMPLATE_NOT_FOUND = "40002";

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.local.auth.smsotp.provider.model.SMSData;
 import org.wso2.carbon.identity.notification.sender.tenant.config.dto.SMSSenderDTO;
 import org.wso2.carbon.identity.notification.sender.tenant.config.exception.NotificationSenderManagementException;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
@@ -125,6 +126,11 @@ public class SMSNotificationHandler extends DefaultNotificationHandler {
         String orgName = SMSNotificationUtil.resolveHumanReadableOrganizationName((String) event.getEventProperties()
                 .get(NotificationConstants.TENANT_DOMAIN));
         notificationData.put(SMSNotificationConstants.PLACEHOLDER_ORGANIZATION_NAME, orgName);
+
+        // This is added to support the use of current year in the SMS template.
+        int currentYear = Calendar.getInstance().get(Calendar.YEAR);
+        notificationData.put(SMSNotificationConstants.PLACE_HOLDER_CURRENT_YEAR, String.valueOf(currentYear));
+
         String template = notificationData.get(SMSNotificationConstants.BODY_TEMPLATE);
         if (StringUtils.isBlank(template)) {
             throw new IdentityEventException(SMSNotificationConstants.ERROR_CODE_TEMPLATE_NOT_FOUND,


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/23641

## Purpose
Add support for `{{current-year}}` literal to dynamically set the calendar year.

## Related issues
- https://github.com/wso2/product-is/issues/23641

## References
Reference logic for email otp: https://github.com/wso2-extensions/identity-event-handler-notification/blob/d4cf4dbe9c6f5816e59d3ca3fe104ae881625a8c/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java#L765-L767