### PR TITLE
Support 'otpToken' placeholder in SMS templates

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
@@ -43,6 +43,7 @@ public class SMSNotificationConstants {
     public static final String PLACEHOLDER_ORGANIZATION_NAME = "organization-name";
     public static final String PLACE_HOLDER_APPLICATION_NAME = "application-name";
     public static final String PLACE_HOLDER_CURRENT_YEAR = "current-year";
+    public static final String PLACE_HOLDER_OTP_TOKEN = "otpToken";
 
     public static final String ERROR_CODE_MISSING_SMS_SENDER = "40001";
     public static final String ERROR_CODE_TEMPLATE_NOT_FOUND = "40002";

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationUtil.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationUtil.java
@@ -78,6 +78,7 @@ public class SMSNotificationUtil {
         OTP otp = (OTP) dataMap.get(SMSNotificationConstants.OTP_TOKEN_PROPERTY_NAME);
         if (otp != null) {
             notificationData.put(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE, otp.getValue());
+            notificationData.put(SMSNotificationConstants.PLACE_HOLDER_OTP_TOKEN, otp.getValue());
             notificationData.put(SMSNotificationConstants.PLACE_HOLDER_OTP_EXPIRY_TIME,
                     String.valueOf(TimeUnit.MILLISECONDS.toMinutes(otp.getValidityPeriodInMillis())));
         } else {


### PR DESCRIPTION
## Purpose
> The "otpToken" placeholder was not being resoleved in the SMSOTP sms template.
> This PR fixes this issue by adding support for the placeholder.

### Before fix 

https://github.com/user-attachments/assets/3414e354-81d8-4709-914a-d882e3ddca75

### After fix 

https://github.com/user-attachments/assets/9396947b-de17-45eb-bab6-e8e90559403e

### Related Issue/s 
- https://github.com/wso2/product-is/issues/24187 


