### PR TITLE
Add password reset template and update OTP handling logic

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
@@ -47,9 +47,7 @@ import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.
  */
 public class SMSOTPExecutor extends AbstractOTPExecutor {
 
-    private static final String PASSWORD_RECOVERY = "PASSWORD_RECOVERY";
     private static final String REGISTRATION = "REGISTRATION";
-    private static final String ASK_PASSWORD = "ASK_PASSWORD";
 
     @Override
     public String getName() {
@@ -66,7 +64,7 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
     }
 
     @Override
-    public ExecutorResponse rollback(FlowExecutionContext flowExecutionContext) throws FlowEngineException {
+    public ExecutorResponse rollback(FlowExecutionContext flowExecutionContext) {
 
         return null;
     }
@@ -167,11 +165,8 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
         switch (flowExecutionContext.getFlowType()) {
             case REGISTRATION:
                 return SMS_OTP_VERIFICATION_TEMPLATE;
-            case PASSWORD_RECOVERY:
-            case ASK_PASSWORD:
-                return PASSWORD_RESET_TEMPLATE;
             default:
-                return null;
+                return PASSWORD_RESET_TEMPLATE;
         }
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
@@ -39,10 +39,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.PASSWORD_RESET_TEMPLATE;
+import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.SMS_OTP_VERIFICATION_TEMPLATE;
+
 /**
  * SMS OTP executor class.
  */
 public class SMSOTPExecutor extends AbstractOTPExecutor {
+
+    private static final String PASSWORD_RECOVERY = "PASSWORD_RECOVERY";
+    private static final String REGISTRATION = "REGISTRATION";
+    private static final String ASK_PASSWORD = "ASK_PASSWORD";
 
     @Override
     public String getName() {
@@ -66,10 +73,11 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
 
     @Override
     protected Event getSendOTPEvent(OTPExecutorConstants.OTPScenarios scenario, OTP otp,
-                                    FlowExecutionContext registrationContext) throws FlowEngineServerException {
+                                    FlowExecutionContext flowExecutionContext) throws FlowEngineServerException {
 
         Map<String, Object> metaProperties = new HashMap<>();
-        String mobile = String.valueOf(registrationContext.getFlowUser()
+        String smsTemplate = resolveOTPTemplate(flowExecutionContext);
+        String mobile = String.valueOf(flowExecutionContext.getFlowUser()
                 .getClaim(SMSOTPConstants.Claims.MOBILE_CLAIM));
 
         metaProperties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL,
@@ -77,9 +85,9 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
         metaProperties.put(SMSOTPConstants.ATTRIBUTE_SMS_SENT_TO, mobile);
         metaProperties.put(SMSOTPConstants.OTP_TOKEN, otp);
         metaProperties.put(SMSOTPConstants.ConnectorConfig.OTP_EXPIRY_TIME, String.valueOf(
-                SMSOTPExecutorUtils.getOTPValidityPeriod(registrationContext.getTenantDomain()) / 60000));
-        metaProperties.put(SMSOTPConstants.TEMPLATE_TYPE, SMSOTPConstants.SMS_OTP_VERIFICATION_TEMPLATE);
-        metaProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, registrationContext.getTenantDomain());
+                SMSOTPExecutorUtils.getOTPValidityPeriod(flowExecutionContext.getTenantDomain()) / 60000));
+        metaProperties.put(SMSOTPConstants.TEMPLATE_TYPE, smsTemplate);
+        metaProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, flowExecutionContext.getTenantDomain());
 
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
@@ -97,9 +105,9 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
     }
 
     @Override
-    protected void handleClaimUpdate(FlowExecutionContext registrationContext, ExecutorResponse executorResponse) {
+    protected void handleClaimUpdate(FlowExecutionContext flowExecutionContext, ExecutorResponse executorResponse) {
 
-        String mobileNumber = (String) registrationContext.getFlowUser()
+        String mobileNumber = (String) flowExecutionContext.getFlowUser()
                 .getClaim(SMSOTPConstants.Claims.MOBILE_CLAIM);
         Map<String, Object> updatedClaims = new HashMap<>();
         updatedClaims.put(SMSOTPConstants.Claims.VERIFIED_MOBILE_NUMBERS_CLAIM, mobileNumber);
@@ -125,7 +133,7 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
     }
 
     @Override
-    protected int getMaxRetryCount(FlowExecutionContext registrationContext) {
+    protected int getMaxRetryCount(FlowExecutionContext flowExecutionContext) {
 
         return 3;
     }
@@ -137,7 +145,7 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
     }
 
     @Override
-    protected int getMaxResendCount(FlowExecutionContext registrationContext) {
+    protected int getMaxResendCount(FlowExecutionContext flowExecutionContext) {
 
         return 3;
     }
@@ -152,5 +160,18 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
     protected String getPostOTPValidatedEventName() {
 
         return IdentityEventConstants.Event.POST_VALIDATE_SMS_OTP;
+    }
+
+    private String resolveOTPTemplate(FlowExecutionContext flowExecutionContext) {
+
+        switch (flowExecutionContext.getFlowType()) {
+            case REGISTRATION:
+                return SMS_OTP_VERIFICATION_TEMPLATE;
+            case PASSWORD_RECOVERY:
+            case ASK_PASSWORD:
+                return PASSWORD_RESET_TEMPLATE;
+            default:
+                return null;
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
@@ -43,6 +43,7 @@ public class SMSOTPConstants {
     public static final String DISPLAY_USERNAME = "Username";
     public static final String PASSWORD = "password";
     public static final String SMS_OTP_VERIFICATION_TEMPLATE = "SMSOTPVerification";
+    public static final String PASSWORD_RESET_TEMPLATE = "passwordReset";
 
     // OTP generation.
     public static final String SMS_OTP_NUMERIC_CHAR_SET = "9245378016";

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutorTest.java
@@ -25,6 +25,7 @@ public class SMSOTPExecutorTest {
 
     private static final String CARBON_SUPER = "carbon.super";
     private static final SMSOTPExecutor smsotpExecutor = new SMSOTPExecutor();
+    private static final String REGISTRATION = "REGISTRATION";
 
     private static FlowExecutionContext flowExecutionContext;
     private static MockedStatic<SMSOTPExecutorUtils> mockedSMSOTPExecutorUtils;
@@ -73,6 +74,7 @@ public class SMSOTPExecutorTest {
 
         mockedSMSOTPExecutorUtils.when(() -> SMSOTPExecutorUtils.getOTPValidityPeriod(CARBON_SUPER)).thenReturn(600000L);
 
+        flowExecutionContext.setFlowType(REGISTRATION);
         Event event = smsotpExecutor.getSendOTPEvent(OTPExecutorConstants.OTPScenarios.INITIAL_OTP, otp, flowExecutionContext);
 
         Assert.assertEquals(event.getEventName(), SMSOTPConstants.EVENT_TRIGGER_NAME);


### PR DESCRIPTION
## Purpose
This pull request introduces enhancements to the `SMSOTPExecutor` class in the SMS OTP authenticator module, primarily aimed at improving OTP template resolution based on flow type and standardizing method parameters for better readability and maintainability. It also updates the corresponding constants and test cases.

### Enhancements to OTP Template Resolution:
* Added a private `resolveOTPTemplate` method in `SMSOTPExecutor` to determine the appropriate OTP template (`SMS_OTP_VERIFICATION_TEMPLATE` or `PASSWORD_RESET_TEMPLATE`) based on the flow type (`REGISTRATION`, `PASSWORD_RECOVERY`, or `ASK_PASSWORD`).
* Introduced constants `PASSWORD_RESET_TEMPLATE` and `REGISTRATION` in `SMSOTPConstants` to support the new template resolution logic. [[1]](diffhunk://#diff-be8e7f56553085fd55e670468e3f4c2cf51f46b10d625067d8b0aed760862108R46) [[2]](diffhunk://#diff-68ee42613986636036589852b9d47df0510de31b3730fd1e76dc5f2a9a6f99aeR42-R53)

### Standardization of Method Parameters:
* Replaced references to `registrationContext` with `flowExecutionContext` across multiple methods in `SMSOTPExecutor`, including `getSendOTPEvent`, `handleClaimUpdate`, `getMaxRetryCount`, and `getMaxResendCount`, to ensure consistent naming and clarity. [[1]](diffhunk://#diff-68ee42613986636036589852b9d47df0510de31b3730fd1e76dc5f2a9a6f99aeL69-R90) [[2]](diffhunk://#diff-68ee42613986636036589852b9d47df0510de31b3730fd1e76dc5f2a9a6f99aeL100-R110) [[3]](diffhunk://#diff-68ee42613986636036589852b9d47df0510de31b3730fd1e76dc5f2a9a6f99aeL128-R136) [[4]](diffhunk://#diff-68ee42613986636036589852b9d47df0510de31b3730fd1e76dc5f2a9a6f99aeL140-R148)

### Updates to Test Cases:
* Modified `SMSOTPExecutorTest` to set the `flowType` as `REGISTRATION` in the `testGetSendOTPEvent` method, ensuring the new template resolution logic is tested.
* Added the `REGISTRATION` constant to the test class for consistency with the main implementation.