### PR TITLE
Override getAMRValue method

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
@@ -56,6 +56,12 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
     }
 
     @Override
+    public String getAMRValue() {
+
+        return SMSOTPConstants.SMS_OTP_AUTHENTICATOR_NAME;
+    }
+
+    @Override
     public List<String> getInitiationData() {
 
         List<String> initiationData = new ArrayList<>();

--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,11 @@
 
         <carbon.kernel.version>4.9.16</carbon.kernel.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <carbon.identity.framework.version>7.8.215</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
         <identity.governance.version>1.11.11</identity.governance.version>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <carbon.identity.account.lock.handler.version>1.8.2</carbon.identity.account.lock.handler.version>
-        <identity.auth.otp.commons.version>1.0.12</identity.auth.otp.commons.version>
+        <identity.auth.otp.commons.version>1.0.16</identity.auth.otp.commons.version>
         <identity.event.handler.notification.version>1.7.17</identity.event.handler.notification.version>
         <identity.notification.sender.tenant.config.version>1.7.10</identity.notification.sender.tenant.config.version>
         <identity.organization.management.core.version>1.0.93</identity.organization.management.core.version>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

### Depends on

https://github.com/wso2-extensions/identity-auth-otp-commons/pull/22

This pull request introduces a minor feature enhancement to the SMS OTP authenticator and updates key dependency versions to ensure compatibility and access to recent improvements.

**Feature enhancement:**

* Added the `getAMRValue()` method to the `SMSOTPExecutor` class, returning the appropriate Authentication Method Reference value for SMS OTP.

**Dependency updates:**

* Updated the `carbon.identity.framework.version` from `7.8.215` to `7.8.403` in `pom.xml` to use the latest identity framework.
* Updated the `identity.auth.otp.commons.version` from `1.0.12` to `1.0.16` in `pom.xml` for improved OTP commons support.