### PR TITLE
Honour file based enableRetryFromAuthenticator config

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/pom.xml
@@ -135,6 +135,7 @@
                         </Export-Package>
                         <Import-Package>
                             org.apache.commons.logging; version="${org.apache.commons.logging.range}",
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
 

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.local.auth.smsotp.authenticator;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
@@ -165,6 +166,10 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
     @Override
     public boolean retryAuthenticationEnabled() {
 
+        Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
+        if (MapUtils.isNotEmpty(parameterMap)) {
+            return Boolean.parseBoolean(parameterMap.get(ENABLE_RETRY_FROM_AUTHENTICATOR));
+        }
         return true;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <com.twilio.sdk.version>9.14.0.wso2v1</com.twilio.sdk.version>
 
         <org.apache.commons.logging.range>[1.2.0,2.0.0)</org.apache.commons.logging.range>
+        <commons-collections.wso2.osgi.version.range>[3.2.0,4.0.0)</commons-collections.wso2.osgi.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <carbon.kernel.package.import.version.range>[4.6.0, 5.0.0)</carbon.kernel.package.import.version.range>


### PR DESCRIPTION
fixes https://github.com/wso2/product-is/issues/24521

By default the server will always have a value for the config as it is configured in the default.json[1]. Current file based config default value is set to true

https://github.com/wso2/carbon-identity-framework/blob/v7.8.416/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json#L243