### PR TITLE
Add custom notification template to the SMS OTP from runtime params through adaptive script

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
@@ -44,6 +44,7 @@ public class SMSOTPConstants {
     public static final String PASSWORD = "password";
     public static final String SMS_OTP_VERIFICATION_TEMPLATE = "SMSOTPVerification";
     public static final String PASSWORD_RESET_TEMPLATE = "passwordReset";
+    public static final String SMS_TEMPLATE_TYPE = "notificationTemplate";
 
     // OTP generation.
     public static final String SMS_OTP_NUMERIC_CHAR_SET = "9245378016";


### PR DESCRIPTION
## Purpose
- Part of the fix for : https://github.com/wso2/product-is/issues/24128

## Tests
1. When the SMS sending is configured from the SMS Publisher, `notificationTemplate` should be the name of the SMS template that we need to use for the SMS.
```
executeStep(2, {
    authenticationOptions: '"SMS OTP"',
    authenticatorParams: {
        local: {
            'sms-otp-authenticator': {
                notificationTemplate: "customSMSTemplate"
            }
        }
    }
}, {})
```

<img width="1591" height="408" alt="Screenshot 2025-09-16 at 2 16 58 PM" src="https://github.com/user-attachments/assets/2cd16d0c-e752-438e-98f4-20276abacff3" />

2. When the notification template is not configured.

<img width="1591" height="408" alt="Screenshot 2025-09-16 at 2 19 31 PM" src="https://github.com/user-attachments/assets/0f5f91f2-7798-455b-b284-00dfee65015e" />
