### PR TITLE
Handle mobile not existing

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
@@ -166,6 +166,12 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
         return IdentityEventConstants.Event.POST_VALIDATE_SMS_OTP;
     }
 
+    @Override
+    protected boolean validateInitiation(FlowExecutionContext context) {
+
+        return context.getFlowUser().getClaim(SMSOTPConstants.Claims.MOBILE_CLAIM) != null;
+    }
+
     private String resolveOTPTemplate(FlowExecutionContext flowExecutionContext) {
 
         switch (flowExecutionContext.getFlowType()) {

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <identity.governance.version>1.11.126</identity.governance.version>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <carbon.identity.account.lock.handler.version>1.8.2</carbon.identity.account.lock.handler.version>
-        <identity.auth.otp.commons.version>1.0.17</identity.auth.otp.commons.version>
+        <identity.auth.otp.commons.version>1.0.22</identity.auth.otp.commons.version>
         <identity.event.handler.notification.version>1.7.17</identity.event.handler.notification.version>
         <identity.notification.sender.tenant.config.version>1.7.10</identity.notification.sender.tenant.config.version>
         <identity.organization.management.core.version>1.0.93</identity.organization.management.core.version>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25636

This pull request adds an extra validation step to the SMS OTP authentication flow to ensure that the user has a mobile number claim before proceeding. This helps prevent issues during OTP initiation for users without a registered mobile number.

Enhancement to SMS OTP initiation:

* Added an override of the `validateInitiation` method in `SMSOTPExecutor.java` to check that the user's `MOBILE_CLAIM` is not null before initiating the OTP flow.