### PR TITLE
Add connector configuration support for user-based SMS OTP resend blocking

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -453,7 +453,8 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
     @Override
     protected boolean isUserBasedOTPResendBlockingEnabled() throws AuthenticationFailedException {
 
-        return true;
+        Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
+        return Boolean.parseBoolean(parameterMap.get(SMSOTPConstants.SMS_OTP_USER_BASED_RESEND_BLOCKING_ENABLED));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -102,6 +102,8 @@ public class SMSOTPConstants {
     public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
     public static final String SEND_MASKED_MOBILE_IN_APPNATIVE_MFA = "sendMaskedMobileInAppNativeMFA";
     public static final String IS_REDIRECT_TO_SMS_OTP = "isRedirectToSmsOTP";
+    public static final String SMS_OTP_USER_BASED_RESEND_BLOCKING_ENABLED = "EnableUserBasedResendBlocking";
+
     /**
      * Authenticator config related configurations.
      */


### PR DESCRIPTION
## Purpose
$subject

Related:  https://github.com/wso2-extensions/identity-local-auth-smsotp/pull/62

Add the below configuration to enable this:

```
[authentication.authenticator.sms_otp_local.parameters]
EnableUserBasedResendBlocking = "true"
```