### PR TITLE
Add mobile verification on update code expiry time to notification data map

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
@@ -33,6 +33,7 @@ public class SMSNotificationConstants {
     public static final String OTP_TOKEN_PROPERTY_NAME = "otpToken";
     public static final String OTP_TOKEN_STRING_PROPERTY_NAME = "otpTokenString";
     public static final String BODY_TEMPLATE = "body-template";
+    public static final String VERIFICATION_OTP_EXPIRY_TIME = "verificationOtpExpiryTime";
 
     public static final String PLACE_HOLDER_REGEX = "\\{\\{([a-zA-Z0-9\\-\\.]+?)\\}\\}";
     public static final String PLACE_HOLDER_CONFIRMATION_CODE = "confirmation-code";

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationUtil.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/internal/SMSNotificationUtil.java
@@ -36,6 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.SMSNotificationConstants.OTP_TOKEN_STRING_PROPERTY_NAME;
+import static org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.SMSNotificationConstants.VERIFICATION_OTP_EXPIRY_TIME;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 
@@ -85,6 +86,10 @@ public class SMSNotificationUtil {
             String otpCode = (String) dataMap.get(OTP_TOKEN_STRING_PROPERTY_NAME);
             if (StringUtils.isNotBlank(otpCode)) {
                 notificationData.put(SMSNotificationConstants.PLACE_HOLDER_CONFIRMATION_CODE, otpCode);
+            }
+            String verificationOtpExpiryTime = (String) dataMap.get(VERIFICATION_OTP_EXPIRY_TIME);
+            if (StringUtils.isNotBlank(verificationOtpExpiryTime)) {
+                notificationData.put(SMSNotificationConstants.PLACE_HOLDER_OTP_EXPIRY_TIME, verificationOtpExpiryTime);
             }
         }
     }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationUtilTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationUtilTest.java
@@ -103,9 +103,25 @@ public class SMSNotificationUtilTest {
                     }, new HashMap<String, String>(), "123456", "5"
                 },
                 {
-                    new HashMap<String, String>() {
+                    new HashMap<String, Object>() {
                         {
                             put(SMSNotificationConstants.OTP_TOKEN_STRING_PROPERTY_NAME, "123456");
+                        }
+                    }, new HashMap<String, String>(), "123456", null
+                },
+                {
+                    new HashMap<String, Object>() {
+                        {
+                            put(SMSNotificationConstants.OTP_TOKEN_STRING_PROPERTY_NAME, "123456");
+                            put(SMSNotificationConstants.VERIFICATION_OTP_EXPIRY_TIME, "10");
+                        }
+                    }, new HashMap<String, String>(), "123456", "10"
+                },
+                {
+                    new HashMap<String, Object>() {
+                        {
+                            put(SMSNotificationConstants.OTP_TOKEN_STRING_PROPERTY_NAME, "123456");
+                            put(SMSNotificationConstants.VERIFICATION_OTP_EXPIRY_TIME, "");
                         }
                     }, new HashMap<String, String>(), "123456", null
                 }


### PR DESCRIPTION
## Purpose
- $subject
- OTP expiry time is added from https://github.com/wso2-extensions/identity-governance/pull/1129
- From this change the expiry time will be added to the notification data map and that can be used in the SMS notification templates by adding {{otp-expiry-time}} placeholder.