### PR TITLE
Add configurable support for surfacing SMS provider failures during OTP authentication

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationMa
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants;
 import org.wso2.carbon.identity.local.auth.smsotp.authenticator.exception.SMSOTPAuthenticatorServerException;
@@ -168,6 +169,18 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
                 return Integer.parseInt(configuredOTPLength);
             }
             return SMSOTPConstants.DEFAULT_OTP_LENGTH;
+        } catch (SMSOTPAuthenticatorServerException exception) {
+            throw handleAuthErrorScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_CONFIG);
+        }
+    }
+
+    private boolean isNotifySmsSendingFailureEnabled(String tenantDomain) throws AuthenticationFailedException {
+
+        try {
+            String config = AuthenticatorUtils
+                    .getSmsAuthenticatorConfig(SMSOTPConstants.ConnectorConfig.SMS_OTP_NOTIFY_SMS_SENDING_FAILURE,
+                            tenantDomain);
+            return Boolean.parseBoolean(config);
         } catch (SMSOTPAuthenticatorServerException exception) {
             throw handleAuthErrorScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_CONFIG);
         }
@@ -393,25 +406,70 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
         String maskedMobileNumber = getMaskedUserClaimValue(authenticatedUser, tenantDomain, isInitialFederationAttempt,
                 authenticationContext);
         setAuthenticatorMessage(authenticationContext, maskedMobileNumber);
+        if (isNotifySmsSendingFailureEnabled(tenantDomain)) {
+            metaProperties.put(SMSOTPConstants.NOTIFY_SPECIFIC_PROVIDER_FAILURES, Boolean.TRUE.toString());
+        }
         /* SaaS apps are created at the super tenant level and they can be accessed by users of other organizations.
         If users of other organizations try to login to a saas app, the sms notification should be triggered from the
         sms provider configured for that organization. Hence, we need to start a new tenanted flow here. */
         if (authenticationContext.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
             try {
                 FrameworkUtils.startTenantFlow(authenticatedUser.getTenantDomain());
-                triggerOtpEvent(SMSOTPConstants.EVENT_TRIGGER_NAME, authenticatedUser, metaProperties);
+                triggerOtpEvent(SMSOTPConstants.EVENT_TRIGGER_NAME, authenticatedUser, metaProperties,
+                        authenticationContext);
             } finally {
                 FrameworkUtils.endTenantFlow();
             }
         } else {
-            triggerOtpEvent(SMSOTPConstants.EVENT_TRIGGER_NAME, authenticatedUser, metaProperties);
+            triggerOtpEvent(SMSOTPConstants.EVENT_TRIGGER_NAME, authenticatedUser, metaProperties,
+                    authenticationContext);
         }
     }
 
-    protected void triggerOtpEvent(String eventName, AuthenticatedUser authenticatedUser, Map<String,
-            Object> eventProperties) throws AuthenticationFailedException {
+    protected void triggerOtpEvent(String eventName, AuthenticatedUser authenticatedUser,
+            Map<String, Object> eventProperties) throws AuthenticationFailedException {
 
         triggerEvent(eventName, authenticatedUser, eventProperties);
+    }
+
+    protected void triggerOtpEvent(String eventName, AuthenticatedUser authenticatedUser,
+            Map<String, Object> eventProperties, AuthenticationContext context) throws AuthenticationFailedException {
+
+        try {
+            triggerOtpEvent(eventName, authenticatedUser, eventProperties);
+        } catch (AuthenticationFailedException e) {
+            if (context != null
+                    && isNotifySmsSendingFailureEnabled(context.getTenantDomain())
+                    && e.getCause() instanceof IdentityEventException) {
+                IdentityEventException cause = (IdentityEventException) e.getCause();
+                String providerErrorCode = cause.getErrorCode();
+                if (StringUtils.isNotBlank(providerErrorCode)
+                        && providerErrorCode.startsWith(SMSOTPConstants.SMS_PROVIDER_ERROR_CODE_PREFIX)) {
+                    AuthenticatorMessage authenticatorMessage = new AuthenticatorMessage(
+                            FrameworkConstants.AuthenticatorMessageType.ERROR,
+                            providerErrorCode, cause.getMessage(), null);
+                    setAuthenticatorMessage(authenticatorMessage, context);
+                    return;
+                }
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    protected String getOTPPageRedirectErrorCode(AuthenticationContext context) throws AuthenticationFailedException {
+
+        if (isNotifySmsSendingFailureEnabled(context.getTenantDomain())) {
+            AuthenticatorMessage authenticatorMessage =
+                (AuthenticatorMessage) context.getProperty(AUTHENTICATOR_MESSAGE);
+            if (authenticatorMessage != null
+                    && FrameworkConstants.AuthenticatorMessageType.ERROR.equals(authenticatorMessage.getType())
+                    && authenticatorMessage.getCode() != null
+                    && authenticatorMessage.getCode().startsWith(SMSOTPConstants.SMS_PROVIDER_ERROR_CODE_PREFIX)) {
+                return authenticatorMessage.getCode();
+            }
+        }
+        return null;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticator.java
@@ -99,7 +99,7 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
 
     private static final Log LOG = LogFactory.getLog(SMSOTPAuthenticator.class);
     private static final long serialVersionUID = 850244886656426295L;
-    private static final String AUTHENTICATOR_MESSAGE = "authenticatorMessage";
+
     private static final String SMS_OTP_SENT = "SMSOTPSent";
     private static final String MASKED_MOBILE_NUMBER = "maskedMobileNumber";
 
@@ -461,7 +461,7 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
 
         if (isNotifySmsSendingFailureEnabled(context.getTenantDomain())) {
             AuthenticatorMessage authenticatorMessage =
-                (AuthenticatorMessage) context.getProperty(AUTHENTICATOR_MESSAGE);
+                (AuthenticatorMessage) context.getProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE);
             if (authenticatorMessage != null
                     && FrameworkConstants.AuthenticatorMessageType.ERROR.equals(authenticatorMessage.getType())
                     && authenticatorMessage.getCode() != null
@@ -550,7 +550,7 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
         AuthenticatorMessage authenticatorMessage = new AuthenticatorMessage(FrameworkConstants.
                 AuthenticatorMessageType.INFO, SMS_OTP_SENT, message, messageContext);
 
-        context.setProperty(AUTHENTICATOR_MESSAGE, authenticatorMessage);
+        context.setProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE, authenticatorMessage);
     }
 
     private boolean doSendMaskedMobileInAppNativeMFA() {
@@ -719,7 +719,7 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
 
     private static void setAuthenticatorMessage(AuthenticatorMessage errorMessage, AuthenticationContext context) {
 
-        context.setProperty(AUTHENTICATOR_MESSAGE, errorMessage);
+        context.setProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE, errorMessage);
     }
 
 
@@ -893,9 +893,9 @@ public class SMSOTPAuthenticator extends AbstractOTPAuthenticator implements Loc
         }
 
         // If the configuration is enabled, and if it is a MFA Option, IS will send the masked mobile number.
-        if (context != null && context.getProperty(AUTHENTICATOR_MESSAGE) != null && doSendMaskedMobileInAppNativeMFA()
+        if (context != null && context.getProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE) != null && doSendMaskedMobileInAppNativeMFA()
                 && !isOTPAsFirstFactor(context)) {
-            authenticatorData.setMessage((AuthenticatorMessage) context.getProperty(AUTHENTICATOR_MESSAGE));
+            authenticatorData.setMessage((AuthenticatorMessage) context.getProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE));
         }
         authenticatorData.setPromptType(FrameworkConstants.AuthenticatorPromptType.USER_PROMPT);
         authenticatorData.setRequiredParams(requiredParams);

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/connector/SMSOTPAuthenticatorConfigImpl.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/connector/SMSOTPAuthenticatorConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -32,6 +32,7 @@ import java.util.Properties;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.ConnectorConfig.OTP_EXPIRY_TIME;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.ConnectorConfig.SMS_OTP_LENGTH;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.ConnectorConfig.SMS_OTP_RESEND_ATTEMPTS_COUNT;
+import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.ConnectorConfig.SMS_OTP_NOTIFY_SMS_SENDING_FAILURE;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.ConnectorConfig.SMS_OTP_RESEND_BLOCK_DURATION;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.ConnectorConfig.SMS_OTP_USE_NUMERIC_CHARS;
 import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.SMSOTPConstants.DEFAULT_OTP_LENGTH;
@@ -85,6 +86,7 @@ public class SMSOTPAuthenticatorConfigImpl implements IdentityConnectorConfig {
         nameMapping.put(SMS_OTP_RESEND_ATTEMPTS_COUNT, "Number of allowed resend attempts");
         nameMapping.put(
                 SMS_OTP_RESEND_BLOCK_DURATION, "Blocking duration in minutes upon exceeding allowed resend attempts");
+        nameMapping.put(SMS_OTP_NOTIFY_SMS_SENDING_FAILURE, "Notify SMS sending failure");
         return nameMapping;
     }
 
@@ -99,6 +101,8 @@ public class SMSOTPAuthenticatorConfigImpl implements IdentityConnectorConfig {
         descriptionMapping.put(SMS_OTP_RESEND_ATTEMPTS_COUNT, "Number of allowed resend attempts of a user");
         descriptionMapping.put(SMS_OTP_RESEND_BLOCK_DURATION, "Time in minutes to block OTP resend " +
                 "functionality upon exceeding allowed resend attempts");
+        descriptionMapping.put(SMS_OTP_NOTIFY_SMS_SENDING_FAILURE,
+                "Enable notifying connection failure errors when connecting to the SMS provider");
         return descriptionMapping;
     }
 
@@ -111,6 +115,7 @@ public class SMSOTPAuthenticatorConfigImpl implements IdentityConnectorConfig {
         properties.add(SMS_OTP_USE_NUMERIC_CHARS);
         properties.add(SMS_OTP_RESEND_ATTEMPTS_COUNT);
         properties.add(SMS_OTP_RESEND_BLOCK_DURATION);
+        properties.add(SMS_OTP_NOTIFY_SMS_SENDING_FAILURE);
         return properties.toArray(new String[0]);
     }
 
@@ -123,12 +128,14 @@ public class SMSOTPAuthenticatorConfigImpl implements IdentityConnectorConfig {
         String otpLength = Integer.toString(DEFAULT_OTP_LENGTH);
         String resendAttempts = Integer.toString(DEFAULT_OTP_RESEND_ATTEMPTS);
         String blockingTime = Integer.toString(DEFAULT_OTP_RESEND_BLOCK_DURATION);
+        String notifySmsSendingFailure = "false";
 
         String otpExpiryTimeProperty = IdentityUtil.getProperty(OTP_EXPIRY_TIME);
         String useNumericCharsProperty = IdentityUtil.getProperty(SMS_OTP_USE_NUMERIC_CHARS);
         String otpLengthProperty = IdentityUtil.getProperty(SMS_OTP_LENGTH);
         String resendAttemptsProperty = IdentityUtil.getProperty(SMS_OTP_RESEND_ATTEMPTS_COUNT);
         String blockingTimeProperty = IdentityUtil.getProperty(SMS_OTP_RESEND_BLOCK_DURATION);
+        String notifySmsSendingFailureProperty = IdentityUtil.getProperty(SMS_OTP_NOTIFY_SMS_SENDING_FAILURE);
 
         if (StringUtils.isNotBlank(otpExpiryTimeProperty)) {
             otpExpiryTime = otpExpiryTimeProperty;
@@ -145,12 +152,16 @@ public class SMSOTPAuthenticatorConfigImpl implements IdentityConnectorConfig {
         if (StringUtils.isNotBlank(blockingTimeProperty)) {
             blockingTime = blockingTimeProperty;
         }
+        if (StringUtils.isNotBlank(notifySmsSendingFailureProperty)) {
+            notifySmsSendingFailure = notifySmsSendingFailureProperty;
+        }
         Map<String, String> defaultProperties = new HashMap<>();
         defaultProperties.put(OTP_EXPIRY_TIME, otpExpiryTime);
         defaultProperties.put(SMS_OTP_USE_NUMERIC_CHARS, useNumericChars);
         defaultProperties.put(SMS_OTP_LENGTH, otpLength);
         defaultProperties.put(SMS_OTP_RESEND_ATTEMPTS_COUNT, resendAttempts);
         defaultProperties.put(SMS_OTP_RESEND_BLOCK_DURATION, blockingTime);
+        defaultProperties.put(SMS_OTP_NOTIFY_SMS_SENDING_FAILURE, notifySmsSendingFailure);
 
         Properties properties = new Properties();
         properties.putAll(defaultProperties);

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
@@ -105,6 +105,7 @@ public class SMSOTPConstants {
     public static final String SMS_OTP_USER_BASED_RESEND_BLOCKING_ENABLED = "EnableUserBasedResendBlocking";
     public static final String SMS_PROVIDER_ERROR_CODE_PREFIX = "SP-";
     public static final String NOTIFY_SPECIFIC_PROVIDER_FAILURES = "notifySpecificProviderFailures";
+    public static final String AUTHENTICATOR_MESSAGE = "authenticatorMessage";
 
     /**
      * Authenticator config related configurations.

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
@@ -103,6 +103,8 @@ public class SMSOTPConstants {
     public static final String SEND_MASKED_MOBILE_IN_APPNATIVE_MFA = "sendMaskedMobileInAppNativeMFA";
     public static final String IS_REDIRECT_TO_SMS_OTP = "isRedirectToSmsOTP";
     public static final String SMS_OTP_USER_BASED_RESEND_BLOCKING_ENABLED = "EnableUserBasedResendBlocking";
+    public static final String SMS_PROVIDER_ERROR_CODE_PREFIX = "SP-";
+    public static final String NOTIFY_SPECIFIC_PROVIDER_FAILURES = "notifySpecificProviderFailures";
 
     /**
      * Authenticator config related configurations.
@@ -114,6 +116,7 @@ public class SMSOTPConstants {
         public static final String SMS_OTP_USE_NUMERIC_CHARS = "SmsOTP.OtpRegex.UseNumericChars";
         public static final String SMS_OTP_RESEND_ATTEMPTS_COUNT = "SmsOTP.ResendAttemptsCount";
         public static final String SMS_OTP_RESEND_BLOCK_DURATION = "SmsOTP.ResendBlockDuration";
+        public static final String SMS_OTP_NOTIFY_SMS_SENDING_FAILURE = "SmsOTP.NotifySmsSendingFailure";
     }
 
     /**

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
@@ -604,7 +604,7 @@ public class SMSOTPAuthenticatorTest {
 
         AuthenticatorMessage errorMessage = new AuthenticatorMessage(
                 FrameworkConstants.AuthenticatorMessageType.ERROR,
-                "SP-60001", "SMS send failed", null);
+                "SP-65001", "SMS send failed", null);
         when(authContext.getProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE)).thenReturn(errorMessage);
 
         try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
@@ -613,7 +613,7 @@ public class SMSOTPAuthenticatorTest {
                     .thenReturn("true");
 
             String result = authenticator.getOTPPageRedirectErrorCode(authContext);
-            Assert.assertEquals(result, "SP-60001",
+            Assert.assertEquals(result, "SP-65001",
                     "Should return the provider error code from authenticatorMessage");
         }
     }
@@ -624,7 +624,7 @@ public class SMSOTPAuthenticatorTest {
         SMSOTPAuthenticator authenticator = spy(new SMSOTPAuthenticator());
         AuthenticatedUser user = mock(AuthenticatedUser.class);
 
-        IdentityEventException cause = new IdentityEventException("SP-60001", "SMS failed");
+        IdentityEventException cause = new IdentityEventException("SP-65001", "SMS failed");
         AuthenticationFailedException thrownException =
                 new AuthenticationFailedException("SMS OTP send failed", cause);
         doThrow(thrownException).when(authenticator)
@@ -646,7 +646,7 @@ public class SMSOTPAuthenticatorTest {
         AuthenticationContext authContext = mock(AuthenticationContext.class);
         when(authContext.getTenantDomain()).thenReturn("carbon.super");
 
-        IdentityEventException cause = new IdentityEventException("SP-60001", "SMS failed");
+        IdentityEventException cause = new IdentityEventException("SP-65001", "SMS failed");
         AuthenticationFailedException thrownException =
                 new AuthenticationFailedException("SMS OTP send failed", cause);
         doThrow(thrownException).when(authenticator)
@@ -676,7 +676,7 @@ public class SMSOTPAuthenticatorTest {
         AuthenticationContext authContext = mock(AuthenticationContext.class);
         when(authContext.getTenantDomain()).thenReturn("carbon.super");
 
-        IdentityEventException cause = new IdentityEventException("SP-60001", "SMS failed");
+        IdentityEventException cause = new IdentityEventException("SP-65001", "SMS failed");
         AuthenticationFailedException thrownException =
                 new AuthenticationFailedException("SMS OTP send failed", cause);
         doThrow(thrownException).when(authenticator)

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
@@ -399,8 +399,8 @@ public class SMSOTPAuthenticatorTest {
         AuthenticatorMessage authenticatorMessage = new AuthenticatorMessage(FrameworkConstants.
                 AuthenticatorMessageType.INFO, "SMSOTPSent", message, messageContext);
         messageContext.put("maskedMobileNumber", maskedMobileNumber);
-        context.setProperty("authenticatorMessage", authenticatorMessage);
-        when(context.getProperty("authenticatorMessage")).thenReturn(authenticatorMessage);
+        context.setProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE, authenticatorMessage);
+        when(context.getProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE)).thenReturn(authenticatorMessage);
 
         AuthenticatorConfig authenticatorConfig = mock(AuthenticatorConfig.class);
         Map<String, String> params = new HashMap<>();
@@ -583,7 +583,7 @@ public class SMSOTPAuthenticatorTest {
         SMSOTPAuthenticator authenticator = new SMSOTPAuthenticator();
         AuthenticationContext authContext = mock(AuthenticationContext.class);
         when(authContext.getTenantDomain()).thenReturn("carbon.super");
-        when(authContext.getProperty("authenticatorMessage")).thenReturn(null);
+        when(authContext.getProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE)).thenReturn(null);
 
         try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
             mockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
@@ -605,7 +605,7 @@ public class SMSOTPAuthenticatorTest {
         AuthenticatorMessage errorMessage = new AuthenticatorMessage(
                 FrameworkConstants.AuthenticatorMessageType.ERROR,
                 "SP-60001", "SMS send failed", null);
-        when(authContext.getProperty("authenticatorMessage")).thenReturn(errorMessage);
+        when(authContext.getProperty(SMSOTPConstants.AUTHENTICATOR_MESSAGE)).thenReturn(errorMessage);
 
         try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
             mockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
@@ -690,7 +690,7 @@ public class SMSOTPAuthenticatorTest {
             // Should NOT throw — exception is suppressed and authenticatorMessage is set in context.
             authenticator.triggerOtpEvent("eventName", user, new HashMap<>(), authContext);
 
-            verify(authContext).setProperty(eq("authenticatorMessage"), any(AuthenticatorMessage.class));
+            verify(authContext).setProperty(eq(SMSOTPConstants.AUTHENTICATOR_MESSAGE), any(AuthenticatorMessage.class));
         }
     }
 

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
@@ -486,10 +486,14 @@ public class SMSOTPAuthenticatorTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         AuthenticationContext context = mock(AuthenticationContext.class);
 
-        try (MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class);
+        try (MockedStatic<AuthenticatorUtils> authenticatorUtilsMockedStatic = mockStatic(AuthenticatorUtils.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class);
              MockedStatic<MultitenantUtils> multitenantUtilsMockedStatic = mockStatic(MultitenantUtils.class);
              MockedStatic<FrameworkUtils> frameworkUtilsMockedStatic = mockStatic(FrameworkUtils.class)) {
 
+            authenticatorUtilsMockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
+                            SMSOTPConstants.ConnectorConfig.SMS_OTP_NOTIFY_SMS_SENDING_FAILURE, "carbon.super"))
+                    .thenReturn("false");
             identityTenantUtilMockedStatic.when(() -> IdentityTenantUtil.getTenantId("carbon.super")).
                     thenReturn(-1234);
             when(mockedRealmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorParamMetadata;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
@@ -71,6 +72,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
@@ -552,5 +554,170 @@ public class SMSOTPAuthenticatorTest {
                 "Retry attempts property key should not be null");
         Assert.assertEquals(retryAttemptsPropertyKey, SMSOTPConstants.SMS_OTP_RETRY_ATTEMPTS_PROPERTY_NAME,
                 "Retry attempts property key should match SMS_OTP_RETRY_ATTEMPTS_PROPERTY_NAME");
+    }
+
+    @Test
+    public void testGetOTPPageRedirectErrorCode_NotifyDisabled_ReturnsNull() throws Exception {
+
+        SMSOTPAuthenticator authenticator = new SMSOTPAuthenticator();
+        AuthenticationContext authContext = mock(AuthenticationContext.class);
+        when(authContext.getTenantDomain()).thenReturn("carbon.super");
+
+        try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
+            mockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
+                            SMSOTPConstants.ConnectorConfig.SMS_OTP_NOTIFY_SMS_SENDING_FAILURE, "carbon.super"))
+                    .thenReturn("false");
+
+            String result = authenticator.getOTPPageRedirectErrorCode(authContext);
+            Assert.assertNull(result, "Should return null when notify SMS sending failure is disabled");
+        }
+    }
+
+    @Test
+    public void testGetOTPPageRedirectErrorCode_NotifyEnabled_NoMessage_ReturnsNull() throws Exception {
+
+        SMSOTPAuthenticator authenticator = new SMSOTPAuthenticator();
+        AuthenticationContext authContext = mock(AuthenticationContext.class);
+        when(authContext.getTenantDomain()).thenReturn("carbon.super");
+        when(authContext.getProperty("authenticatorMessage")).thenReturn(null);
+
+        try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
+            mockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
+                            SMSOTPConstants.ConnectorConfig.SMS_OTP_NOTIFY_SMS_SENDING_FAILURE, "carbon.super"))
+                    .thenReturn("true");
+
+            String result = authenticator.getOTPPageRedirectErrorCode(authContext);
+            Assert.assertNull(result, "Should return null when no authenticatorMessage is set in context");
+        }
+    }
+
+    @Test
+    public void testGetOTPPageRedirectErrorCode_NotifyEnabled_WithProviderErrorCode_ReturnsCode() throws Exception {
+
+        SMSOTPAuthenticator authenticator = new SMSOTPAuthenticator();
+        AuthenticationContext authContext = mock(AuthenticationContext.class);
+        when(authContext.getTenantDomain()).thenReturn("carbon.super");
+
+        AuthenticatorMessage errorMessage = new AuthenticatorMessage(
+                FrameworkConstants.AuthenticatorMessageType.ERROR,
+                "SP-60001", "SMS send failed", null);
+        when(authContext.getProperty("authenticatorMessage")).thenReturn(errorMessage);
+
+        try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
+            mockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
+                            SMSOTPConstants.ConnectorConfig.SMS_OTP_NOTIFY_SMS_SENDING_FAILURE, "carbon.super"))
+                    .thenReturn("true");
+
+            String result = authenticator.getOTPPageRedirectErrorCode(authContext);
+            Assert.assertEquals(result, "SP-60001",
+                    "Should return the provider error code from authenticatorMessage");
+        }
+    }
+
+    @Test
+    public void testTriggerOtpEventWithContext_NullContext_RethrowsException() throws Exception {
+
+        SMSOTPAuthenticator authenticator = spy(new SMSOTPAuthenticator());
+        AuthenticatedUser user = mock(AuthenticatedUser.class);
+
+        IdentityEventException cause = new IdentityEventException("SP-60001", "SMS failed");
+        AuthenticationFailedException thrownException =
+                new AuthenticationFailedException("SMS OTP send failed", cause);
+        doThrow(thrownException).when(authenticator)
+                .triggerOtpEvent(anyString(), any(AuthenticatedUser.class), anyMap());
+
+        try {
+            authenticator.triggerOtpEvent("eventName", user, new HashMap<>(), null);
+            Assert.fail("Expected AuthenticationFailedException to be rethrown");
+        } catch (AuthenticationFailedException e) {
+            Assert.assertEquals(e, thrownException, "Same exception should be rethrown when context is null");
+        }
+    }
+
+    @Test
+    public void testTriggerOtpEventWithContext_NotifyDisabled_RethrowsException() throws Exception {
+
+        SMSOTPAuthenticator authenticator = spy(new SMSOTPAuthenticator());
+        AuthenticatedUser user = mock(AuthenticatedUser.class);
+        AuthenticationContext authContext = mock(AuthenticationContext.class);
+        when(authContext.getTenantDomain()).thenReturn("carbon.super");
+
+        IdentityEventException cause = new IdentityEventException("SP-60001", "SMS failed");
+        AuthenticationFailedException thrownException =
+                new AuthenticationFailedException("SMS OTP send failed", cause);
+        doThrow(thrownException).when(authenticator)
+                .triggerOtpEvent(anyString(), any(AuthenticatedUser.class), anyMap());
+
+        try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
+            mockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
+                            SMSOTPConstants.ConnectorConfig.SMS_OTP_NOTIFY_SMS_SENDING_FAILURE, "carbon.super"))
+                    .thenReturn("false");
+
+            try {
+                authenticator.triggerOtpEvent("eventName", user, new HashMap<>(), authContext);
+                Assert.fail("Expected AuthenticationFailedException to be rethrown");
+            } catch (AuthenticationFailedException e) {
+                Assert.assertEquals(e, thrownException,
+                        "Exception should be rethrown when notify SMS sending failure is disabled");
+            }
+        }
+    }
+
+    @Test
+    public void testTriggerOtpEventWithContext_NotifyEnabled_ProviderErrorCode_SuppressesAndSetsMessage()
+            throws Exception {
+
+        SMSOTPAuthenticator authenticator = spy(new SMSOTPAuthenticator());
+        AuthenticatedUser user = mock(AuthenticatedUser.class);
+        AuthenticationContext authContext = mock(AuthenticationContext.class);
+        when(authContext.getTenantDomain()).thenReturn("carbon.super");
+
+        IdentityEventException cause = new IdentityEventException("SP-60001", "SMS failed");
+        AuthenticationFailedException thrownException =
+                new AuthenticationFailedException("SMS OTP send failed", cause);
+        doThrow(thrownException).when(authenticator)
+                .triggerOtpEvent(anyString(), any(AuthenticatedUser.class), anyMap());
+
+        try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
+            mockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
+                            SMSOTPConstants.ConnectorConfig.SMS_OTP_NOTIFY_SMS_SENDING_FAILURE, "carbon.super"))
+                    .thenReturn("true");
+
+            // Should NOT throw — exception is suppressed and authenticatorMessage is set in context.
+            authenticator.triggerOtpEvent("eventName", user, new HashMap<>(), authContext);
+
+            verify(authContext).setProperty(eq("authenticatorMessage"), any(AuthenticatorMessage.class));
+        }
+    }
+
+    @Test
+    public void testTriggerOtpEventWithContext_NotifyEnabled_NonProviderErrorCode_RethrowsException()
+            throws Exception {
+
+        SMSOTPAuthenticator authenticator = spy(new SMSOTPAuthenticator());
+        AuthenticatedUser user = mock(AuthenticatedUser.class);
+        AuthenticationContext authContext = mock(AuthenticationContext.class);
+        when(authContext.getTenantDomain()).thenReturn("carbon.super");
+
+        // Error code does NOT start with "SP-" prefix.
+        IdentityEventException cause = new IdentityEventException("OTHER-001", "Some other error");
+        AuthenticationFailedException thrownException =
+                new AuthenticationFailedException("SMS OTP send failed", cause);
+        doThrow(thrownException).when(authenticator)
+                .triggerOtpEvent(anyString(), any(AuthenticatedUser.class), anyMap());
+
+        try (MockedStatic<AuthenticatorUtils> mockedStatic = Mockito.mockStatic(AuthenticatorUtils.class)) {
+            mockedStatic.when(() -> AuthenticatorUtils.getSmsAuthenticatorConfig(
+                            SMSOTPConstants.ConnectorConfig.SMS_OTP_NOTIFY_SMS_SENDING_FAILURE, "carbon.super"))
+                    .thenReturn("true");
+
+            try {
+                authenticator.triggerOtpEvent("eventName", user, new HashMap<>(), authContext);
+                Assert.fail("Expected AuthenticationFailedException to be rethrown for non-provider error code");
+            } catch (AuthenticationFailedException e) {
+                Assert.assertEquals(e, thrownException,
+                        "Exception should be rethrown when error code does not start with SP- prefix");
+            }
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -34,6 +34,7 @@ public class SMSNotificationConstants {
     public static final String OTP_TOKEN_STRING_PROPERTY_NAME = "otpTokenString";
     public static final String BODY_TEMPLATE = "body-template";
     public static final String VERIFICATION_OTP_EXPIRY_TIME = "verificationOtpExpiryTime";
+    public static final String NOTIFY_SPECIFIC_PROVIDER_FAILURES = "notifySpecificProviderFailures";
 
     public static final String PLACE_HOLDER_REGEX = "\\{\\{([a-zA-Z0-9\\-\\.]+?)\\}\\}";
     public static final String PLACE_HOLDER_CONFIRMATION_CODE = "confirmation-code";

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationConstants.java
@@ -51,4 +51,5 @@ public class SMSNotificationConstants {
     public static final String ERROR_CODE_TEMPLATE_NOT_FOUND = "40002";
 
     public static final String ERROR_MESSAGE_TEMPLATE_NOT_FOUND = "SMS template not found.";
+    public static final String SMS_PROVIDER_ERROR_CODE_PREFIX = "SP-";
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
@@ -101,13 +101,19 @@ public class SMSNotificationHandler extends DefaultNotificationHandler {
             throw new IdentityEventException("Error while retrieving SMS Sender: "
                     + SMSNotificationConstants.SMS_PUBLISHER_NAME, e);
         } catch (ProviderException e) {
+            String errorCode = e.getErrorCode();
             if (notifySpecificProviderFailures) {
-                String errorCode = e.getErrorCode();
                 String errorMessage = e.getMessage();
                 if (StringUtils.isNotBlank(errorCode) && StringUtils.isNotBlank(errorMessage)) {
                     throw new IdentityEventException(errorCode, errorMessage, e);
                 } else {
                     throw new IdentityEventException(SMS_SEND_FAILED.getCode(), SMS_SEND_FAILED.getMessage(), e);
+                }
+            } else {
+                if (StringUtils.isNotBlank(errorCode) &&
+                    StringUtils.startsWith(errorCode, SMSNotificationConstants.SMS_PROVIDER_ERROR_CODE_PREFIX)) {
+                    // Provider failure notification is disabled; suppress provider-specific errors silently.
+                    return;
                 }
             }
             throw new IdentityEventException("Error while sending SMS", e);

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.SMSNotificationConstants.ERROR_CODE_MISSING_SMS_SENDER;
+import static org.wso2.carbon.identity.local.auth.smsotp.provider.constant.Constants.ErrorMessage.SMS_SEND_FAILED;
 
 /**
  * This class represents the SMS notification handler.
@@ -69,6 +70,8 @@ public class SMSNotificationHandler extends DefaultNotificationHandler {
     public void handleEvent(Event event) throws IdentityEventException {
 
         String tenantDomain = (String) event.getEventProperties().get(NotificationConstants.TENANT_DOMAIN);
+        boolean notifySpecificProviderFailures = Boolean.parseBoolean(
+            (String) event.getEventProperties().get(SMSNotificationConstants.NOTIFY_SPECIFIC_PROVIDER_FAILURES));
         if (LOG.isDebugEnabled()) {
             LOG.debug("Handling SMS notification event for " + tenantDomain);
         }
@@ -98,6 +101,15 @@ public class SMSNotificationHandler extends DefaultNotificationHandler {
             throw new IdentityEventException("Error while retrieving SMS Sender: "
                     + SMSNotificationConstants.SMS_PUBLISHER_NAME, e);
         } catch (ProviderException e) {
+            if (notifySpecificProviderFailures) {
+                String errorCode = e.getErrorCode();
+                String errorMessage = e.getMessage();
+                if (StringUtils.isNotBlank(errorCode) && StringUtils.isNotBlank(errorMessage)) {
+                    throw new IdentityEventException(errorCode, errorMessage, e);
+                } else {
+                    throw new IdentityEventException(SMS_SEND_FAILED.getCode(), SMS_SEND_FAILED.getMessage(), e);
+                }
+            }
             throw new IdentityEventException("Error while sending SMS", e);
         }
     }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandler.java
@@ -113,6 +113,12 @@ public class SMSNotificationHandler extends DefaultNotificationHandler {
                 if (StringUtils.isNotBlank(errorCode) &&
                     StringUtils.startsWith(errorCode, SMSNotificationConstants.SMS_PROVIDER_ERROR_CODE_PREFIX)) {
                     // Provider failure notification is disabled; suppress provider-specific errors silently.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format(
+                                "Suppressed SMS provider failure (code: %s, tenant: %s). "
+                                        + "Enable SmsOTP.NotifySmsSendingFailure to surface this error to the UI.",
+                                errorCode, tenantDomain), e);
+                    }
                     return;
                 }
             }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandlerTest.java
@@ -227,7 +227,7 @@ public class SMSNotificationHandlerTest {
             }
             @Override public void send(SMSData smsData, SMSSenderDTO smsSenderDTO, String tenantDomain)
                     throws ProviderException {
-                throw new ProviderException("SP-60001", "SMS send failed due to authentication failure");
+                throw new ProviderException("SP-65001", "SMS send failed due to authentication failure");
             }
         };
         SMSNotificationHandlerDataHolder.getInstance().addProvider(providerName, failingProvider);
@@ -247,7 +247,7 @@ public class SMSNotificationHandlerTest {
         try {
             smsNotificationHandler.handleEvent(event);
         } catch (IdentityEventException e) {
-            Assert.assertEquals(e.getErrorCode(), "SP-60001",
+            Assert.assertEquals(e.getErrorCode(), "SP-65001",
                     "IdentityEventException should carry the provider error code");
             throw e;
         }
@@ -284,7 +284,7 @@ public class SMSNotificationHandlerTest {
         try {
             smsNotificationHandler.handleEvent(event);
         } catch (IdentityEventException e) {
-            Assert.assertEquals(e.getErrorCode(), "SP-60006",
+            Assert.assertEquals(e.getErrorCode(), "SP-65006",
                     "Should use SMS_SEND_FAILED code when provider exception has no error code");
             throw e;
         }
@@ -301,7 +301,7 @@ public class SMSNotificationHandlerTest {
             }
             @Override public void send(SMSData smsData, SMSSenderDTO smsSenderDTO, String tenantDomain)
                     throws ProviderException {
-                throw new ProviderException("SP-60001", "SMS send failed");
+                throw new ProviderException("SP-65001", "SMS send failed");
             }
         };
         SMSNotificationHandlerDataHolder.getInstance().addProvider(providerName, suppressedProvider);

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandlerTest.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -221,7 +222,9 @@ public class SMSNotificationHandlerTest {
 
         String providerName = "FailingProvider";
         Provider failingProvider = new Provider() {
-            @Override public String getName() { return providerName; }
+            @Override public String getName() {
+                return providerName;
+            }
             @Override public void send(SMSData smsData, SMSSenderDTO smsSenderDTO, String tenantDomain)
                     throws ProviderException {
                 throw new ProviderException("SP-60001", "SMS send failed due to authentication failure");
@@ -234,9 +237,11 @@ public class SMSNotificationHandlerTest {
         smsSenderDTO.setProvider(providerName);
         List<SMSSenderDTO> senders = new ArrayList<>();
         senders.add(smsSenderDTO);
-        when(notificationSenderManagementService.getSMSSenders()).thenReturn(senders);
+        doReturn(senders).when(notificationSenderManagementService).getSMSSenders();
 
         Event event = constructSMSOTPEvent();
+        event.addEventProperty("otpToken", new OTP("874090", 300000, 300000));
+        event.addEventProperty("tenant-domain", "carbon.super");
         event.addEventProperty(SMSNotificationConstants.NOTIFY_SPECIFIC_PROVIDER_FAILURES, "true");
 
         try {
@@ -254,7 +259,9 @@ public class SMSNotificationHandlerTest {
 
         String providerName = "BlankCodeProvider";
         Provider blankCodeProvider = new Provider() {
-            @Override public String getName() { return providerName; }
+            @Override public String getName() {
+                return providerName;
+            }
             @Override public void send(SMSData smsData, SMSSenderDTO smsSenderDTO, String tenantDomain)
                     throws ProviderException {
                 throw new ProviderException("SMS send failed with no specific code");
@@ -267,9 +274,11 @@ public class SMSNotificationHandlerTest {
         smsSenderDTO.setProvider(providerName);
         List<SMSSenderDTO> senders = new ArrayList<>();
         senders.add(smsSenderDTO);
-        when(notificationSenderManagementService.getSMSSenders()).thenReturn(senders);
+        doReturn(senders).when(notificationSenderManagementService).getSMSSenders();
 
         Event event = constructSMSOTPEvent();
+        event.addEventProperty("otpToken", new OTP("874090", 300000, 300000));
+        event.addEventProperty("tenant-domain", "carbon.super");
         event.addEventProperty(SMSNotificationConstants.NOTIFY_SPECIFIC_PROVIDER_FAILURES, "true");
 
         try {
@@ -281,35 +290,71 @@ public class SMSNotificationHandlerTest {
         }
     }
 
-    @Test(expectedExceptions = IdentityEventException.class)
-    public void testHandleEvent_NotifyDisabled_ProviderException_ThrowsGenericMessage()
+    @Test
+    public void testHandleEvent_NotifyDisabled_ProviderExceptionWithSPCode_SuppressedSilently()
             throws IdentityEventException, NotificationSenderManagementException {
 
-        String providerName = "FailingProviderDisabled";
-        Provider failingProvider = new Provider() {
-            @Override public String getName() { return providerName; }
+        String providerName = "SuppressedProvider";
+        Provider suppressedProvider = new Provider() {
+            @Override public String getName() {
+                return providerName;
+            }
             @Override public void send(SMSData smsData, SMSSenderDTO smsSenderDTO, String tenantDomain)
                     throws ProviderException {
                 throw new ProviderException("SP-60001", "SMS send failed");
             }
         };
-        SMSNotificationHandlerDataHolder.getInstance().addProvider(providerName, failingProvider);
+        SMSNotificationHandlerDataHolder.getInstance().addProvider(providerName, suppressedProvider);
 
         SMSSenderDTO smsSenderDTO = new SMSSenderDTO();
         smsSenderDTO.setName(providerName);
         smsSenderDTO.setProvider(providerName);
         List<SMSSenderDTO> senders = new ArrayList<>();
         senders.add(smsSenderDTO);
-        when(notificationSenderManagementService.getSMSSenders()).thenReturn(senders);
+        doReturn(senders).when(notificationSenderManagementService).getSMSSenders();
 
         Event event = constructSMSOTPEvent();
+        event.addEventProperty("otpToken", new OTP("874090", 300000, 300000));
+        event.addEventProperty("tenant-domain", "carbon.super");
+        event.addEventProperty(SMSNotificationConstants.NOTIFY_SPECIFIC_PROVIDER_FAILURES, "false");
+
+        // SP-prefixed provider errors are silently suppressed when notify is disabled.
+        smsNotificationHandler.handleEvent(event);
+    }
+
+    @Test(expectedExceptions = IdentityEventException.class)
+    public void testHandleEvent_NotifyDisabled_ProviderExceptionWithNonSPCode_ThrowsGenericMessage()
+            throws IdentityEventException, NotificationSenderManagementException {
+
+        String providerName = "GenericFailureProvider";
+        Provider genericFailingProvider = new Provider() {
+            @Override public String getName() {
+                return providerName;
+            }
+            @Override public void send(SMSData smsData, SMSSenderDTO smsSenderDTO, String tenantDomain)
+                    throws ProviderException {
+                throw new ProviderException("GENERIC-001", "Some non-provider failure");
+            }
+        };
+        SMSNotificationHandlerDataHolder.getInstance().addProvider(providerName, genericFailingProvider);
+
+        SMSSenderDTO smsSenderDTO = new SMSSenderDTO();
+        smsSenderDTO.setName(providerName);
+        smsSenderDTO.setProvider(providerName);
+        List<SMSSenderDTO> senders = new ArrayList<>();
+        senders.add(smsSenderDTO);
+        doReturn(senders).when(notificationSenderManagementService).getSMSSenders();
+
+        Event event = constructSMSOTPEvent();
+        event.addEventProperty("otpToken", new OTP("874090", 300000, 300000));
+        event.addEventProperty("tenant-domain", "carbon.super");
         event.addEventProperty(SMSNotificationConstants.NOTIFY_SPECIFIC_PROVIDER_FAILURES, "false");
 
         try {
             smsNotificationHandler.handleEvent(event);
         } catch (IdentityEventException e) {
             Assert.assertTrue(e.getMessage().contains("Error while sending SMS"),
-                    "Should throw generic message when notify is disabled");
+                    "Should throw generic message when notify is disabled and error code has no SP- prefix");
             throw e;
         }
     }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.event.handler/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/event/handler/notification/SMSNotificationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -32,6 +32,8 @@ import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.internal.SMSNotificationHandlerDataHolder;
 import org.wso2.carbon.identity.local.auth.smsotp.event.handler.notification.internal.SMSNotificationUtil;
+import org.wso2.carbon.identity.local.auth.smsotp.provider.Provider;
+import org.wso2.carbon.identity.local.auth.smsotp.provider.exception.ProviderException;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.impl.CustomProvider;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.impl.TwilioProvider;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.model.SMSData;
@@ -211,6 +213,105 @@ public class SMSNotificationHandlerTest {
     public void testGetName() {
 
         Assert.assertEquals(smsNotificationHandler.getName(), SMSNotificationConstants.NOTIFICATION_HANDLER_NAME);
+    }
+
+    @Test(expectedExceptions = IdentityEventException.class)
+    public void testHandleEvent_NotifyEnabled_ProviderExceptionWithCode_ThrowsWithProviderCode()
+            throws IdentityEventException, NotificationSenderManagementException {
+
+        String providerName = "FailingProvider";
+        Provider failingProvider = new Provider() {
+            @Override public String getName() { return providerName; }
+            @Override public void send(SMSData smsData, SMSSenderDTO smsSenderDTO, String tenantDomain)
+                    throws ProviderException {
+                throw new ProviderException("SP-60001", "SMS send failed due to authentication failure");
+            }
+        };
+        SMSNotificationHandlerDataHolder.getInstance().addProvider(providerName, failingProvider);
+
+        SMSSenderDTO smsSenderDTO = new SMSSenderDTO();
+        smsSenderDTO.setName(providerName);
+        smsSenderDTO.setProvider(providerName);
+        List<SMSSenderDTO> senders = new ArrayList<>();
+        senders.add(smsSenderDTO);
+        when(notificationSenderManagementService.getSMSSenders()).thenReturn(senders);
+
+        Event event = constructSMSOTPEvent();
+        event.addEventProperty(SMSNotificationConstants.NOTIFY_SPECIFIC_PROVIDER_FAILURES, "true");
+
+        try {
+            smsNotificationHandler.handleEvent(event);
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), "SP-60001",
+                    "IdentityEventException should carry the provider error code");
+            throw e;
+        }
+    }
+
+    @Test(expectedExceptions = IdentityEventException.class)
+    public void testHandleEvent_NotifyEnabled_ProviderExceptionWithoutCode_ThrowsDefaultCode()
+            throws IdentityEventException, NotificationSenderManagementException {
+
+        String providerName = "BlankCodeProvider";
+        Provider blankCodeProvider = new Provider() {
+            @Override public String getName() { return providerName; }
+            @Override public void send(SMSData smsData, SMSSenderDTO smsSenderDTO, String tenantDomain)
+                    throws ProviderException {
+                throw new ProviderException("SMS send failed with no specific code");
+            }
+        };
+        SMSNotificationHandlerDataHolder.getInstance().addProvider(providerName, blankCodeProvider);
+
+        SMSSenderDTO smsSenderDTO = new SMSSenderDTO();
+        smsSenderDTO.setName(providerName);
+        smsSenderDTO.setProvider(providerName);
+        List<SMSSenderDTO> senders = new ArrayList<>();
+        senders.add(smsSenderDTO);
+        when(notificationSenderManagementService.getSMSSenders()).thenReturn(senders);
+
+        Event event = constructSMSOTPEvent();
+        event.addEventProperty(SMSNotificationConstants.NOTIFY_SPECIFIC_PROVIDER_FAILURES, "true");
+
+        try {
+            smsNotificationHandler.handleEvent(event);
+        } catch (IdentityEventException e) {
+            Assert.assertEquals(e.getErrorCode(), "SP-60006",
+                    "Should use SMS_SEND_FAILED code when provider exception has no error code");
+            throw e;
+        }
+    }
+
+    @Test(expectedExceptions = IdentityEventException.class)
+    public void testHandleEvent_NotifyDisabled_ProviderException_ThrowsGenericMessage()
+            throws IdentityEventException, NotificationSenderManagementException {
+
+        String providerName = "FailingProviderDisabled";
+        Provider failingProvider = new Provider() {
+            @Override public String getName() { return providerName; }
+            @Override public void send(SMSData smsData, SMSSenderDTO smsSenderDTO, String tenantDomain)
+                    throws ProviderException {
+                throw new ProviderException("SP-60001", "SMS send failed");
+            }
+        };
+        SMSNotificationHandlerDataHolder.getInstance().addProvider(providerName, failingProvider);
+
+        SMSSenderDTO smsSenderDTO = new SMSSenderDTO();
+        smsSenderDTO.setName(providerName);
+        smsSenderDTO.setProvider(providerName);
+        List<SMSSenderDTO> senders = new ArrayList<>();
+        senders.add(smsSenderDTO);
+        when(notificationSenderManagementService.getSMSSenders()).thenReturn(senders);
+
+        Event event = constructSMSOTPEvent();
+        event.addEventProperty(SMSNotificationConstants.NOTIFY_SPECIFIC_PROVIDER_FAILURES, "false");
+
+        try {
+            smsNotificationHandler.handleEvent(event);
+        } catch (IdentityEventException e) {
+            Assert.assertTrue(e.getMessage().contains("Error while sending SMS"),
+                    "Should throw generic message when notify is disabled");
+            throw e;
+        }
     }
 
     @DataProvider(name = "handleEventDataProvider")

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/constant/Constants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/constant/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -64,7 +64,48 @@ public class Constants {
      */
     public enum ErrorMessage {
 
-        ERROR_UNAUTHORIZED_ACCESS("SMS-65001", "Unauthorized Access - Invalid Credentials provided.");
+        UNAUTHORIZED("SP-60001",
+                "The SMS could not be sent because authentication with the SMS service failed. "
+                        + "Please contact your administrator."),
+        FORBIDDEN("SP-60002",
+                "The SMS could not be sent because the account does not have the required permissions. "
+                        + "Please contact your administrator."),
+        BAD_REQUEST("SP-60003",
+                "The SMS could not be sent because the SMS service did not accept the request. "
+                        + "Please contact your administrator."),
+        TOO_MANY_REQUESTS("SP-60004",
+                "The SMS could not be sent because the SMS service is temporarily busy. "
+                        + "Please try again in a few moments."),
+        SERVER_ERROR("SP-60005",
+                "The SMS could not be sent because the SMS service encountered an unexpected error. "
+                        + "Please try again or contact support."),
+        SMS_SEND_FAILED("SP-60006",
+                "The SMS could not be sent due to an unexpected error. "
+                        + "Please try again or contact your administrator."),
+        MESSAGE_DELIVERY_FAILED("SP-60007",
+                "The SMS could not be delivered. "
+                        + "Please try again or contact your administrator."),
+        INVALID_CONFIGURATION("SP-60008",
+                "The SMS could not be sent because the SMS service is not configured correctly. "
+                        + "Please contact your administrator."),
+        SERVICE_UNREACHABLE("SP-60009",
+                "The SMS could not be sent because the SMS service cannot be reached. "
+                        + "Please contact your administrator."),
+        ACCOUNT_SUSPENDED("SP-60010",
+                "The SMS could not be sent because the messaging account has been suspended. "
+                        + "Please contact your administrator."),
+        ACCOUNT_LIMIT_EXCEEDED("SP-60011",
+                "The SMS could not be sent because the account limit has been reached. "
+                        + "Please contact your administrator."),
+        UNDELIVERABLE_NUMBER("SP-60012",
+                "The SMS could not be delivered. The recipient's number may be switched off, "
+                        + "out of coverage, or not a mobile number. Please check the number and try again."),
+        CARRIER_FILTERED("SP-60013",
+                "The SMS was blocked by the mobile carrier. This can happen due to content filtering "
+                        + "or sender restrictions. Please contact your administrator."),
+        NUMBER_BARRED("SP-60014",
+                "The SMS could not be delivered because the recipient's number is not permitted. "
+                        + "Please contact your administrator.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/constant/Constants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/constant/Constants.java
@@ -64,46 +64,46 @@ public class Constants {
      */
     public enum ErrorMessage {
 
-        UNAUTHORIZED("SP-60001",
+        UNAUTHORIZED("SP-65001",
                 "The SMS could not be sent because authentication with the SMS service failed. "
                         + "Please contact your administrator."),
-        FORBIDDEN("SP-60002",
+        FORBIDDEN("SP-65002",
                 "The SMS could not be sent because the account does not have the required permissions. "
                         + "Please contact your administrator."),
-        BAD_REQUEST("SP-60003",
+        BAD_REQUEST("SP-65003",
                 "The SMS could not be sent because the SMS service did not accept the request. "
                         + "Please contact your administrator."),
-        TOO_MANY_REQUESTS("SP-60004",
+        TOO_MANY_REQUESTS("SP-65004",
                 "The SMS could not be sent because the SMS service is temporarily busy. "
                         + "Please try again in a few moments."),
-        SERVER_ERROR("SP-60005",
+        SERVER_ERROR("SP-65005",
                 "The SMS could not be sent because the SMS service encountered an unexpected error. "
                         + "Please try again or contact support."),
-        SMS_SEND_FAILED("SP-60006",
+        SMS_SEND_FAILED("SP-65006",
                 "The SMS could not be sent due to an unexpected error. "
                         + "Please try again or contact your administrator."),
-        MESSAGE_DELIVERY_FAILED("SP-60007",
+        MESSAGE_DELIVERY_FAILED("SP-65007",
                 "The SMS could not be delivered. "
                         + "Please try again or contact your administrator."),
-        INVALID_CONFIGURATION("SP-60008",
+        INVALID_CONFIGURATION("SP-65008",
                 "The SMS could not be sent because the SMS service is not configured correctly. "
                         + "Please contact your administrator."),
-        SERVICE_UNREACHABLE("SP-60009",
+        SERVICE_UNREACHABLE("SP-65009",
                 "The SMS could not be sent because the SMS service cannot be reached. "
                         + "Please contact your administrator."),
-        ACCOUNT_SUSPENDED("SP-60010",
+        ACCOUNT_SUSPENDED("SP-65010",
                 "The SMS could not be sent because the messaging account has been suspended. "
                         + "Please contact your administrator."),
-        ACCOUNT_LIMIT_EXCEEDED("SP-60011",
+        ACCOUNT_LIMIT_EXCEEDED("SP-65011",
                 "The SMS could not be sent because the account limit has been reached. "
                         + "Please contact your administrator."),
-        UNDELIVERABLE_NUMBER("SP-60012",
+        UNDELIVERABLE_NUMBER("SP-65012",
                 "The SMS could not be delivered. The recipient's number may be switched off, "
                         + "out of coverage, or not a mobile number. Please check the number and try again."),
-        CARRIER_FILTERED("SP-60013",
+        CARRIER_FILTERED("SP-65013",
                 "The SMS was blocked by the mobile carrier. This can happen due to content filtering "
                         + "or sender restrictions. Please contact your administrator."),
-        NUMBER_BARRED("SP-60014",
+        NUMBER_BARRED("SP-65014",
                 "The SMS could not be delivered because the recipient's number is not permitted. "
                         + "Please contact your administrator.");
 

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/exception/ProviderException.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/exception/ProviderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -26,6 +26,8 @@ package org.wso2.carbon.identity.local.auth.smsotp.provider.exception;
  */
 public class ProviderException extends Exception {
 
+    private final String errorCode;
+
     /**
      * Constructs a new exception with the specified detail message.
      *
@@ -34,6 +36,7 @@ public class ProviderException extends Exception {
     public ProviderException(String message) {
 
         super(message);
+        this.errorCode = null;
     }
 
     /**
@@ -45,6 +48,32 @@ public class ProviderException extends Exception {
     public ProviderException(String message, Throwable cause) {
 
         super(message, cause);
+        this.errorCode = null;
+    }
+
+    /**
+     * Constructs a new exception with the specified error code, detail message and cause.
+     *
+     * @param errorCode The error code.
+     * @param message   The detail message.
+     * @param cause     The cause.
+     */
+    public ProviderException(String errorCode, String message, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Constructs a new exception with the specified error code and detail message.
+     *
+     * @param errorCode The error code.
+     * @param message   The detail message.
+     */
+    public ProviderException(String errorCode, String message) {
+
+        super(message);
+        this.errorCode = errorCode;
     }
 
     /**
@@ -55,6 +84,7 @@ public class ProviderException extends Exception {
     public ProviderException(Throwable cause) {
 
         super(cause);
+        this.errorCode = null;
     }
 
     /**
@@ -69,5 +99,16 @@ public class ProviderException extends Exception {
                              boolean writableStackTrace) {
 
         super(message, cause, enableSuppression, writableStackTrace);
+        this.errorCode = null;
+    }
+
+    /**
+     * Returns the error code associated with this exception.
+     *
+     * @return The error code, or null if not set.
+     */
+    public String getErrorCode() {
+
+        return errorCode;
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/exception/PublisherException.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/exception/PublisherException.java
@@ -36,6 +36,19 @@ public class PublisherException extends Exception {
     }
 
     /**
+     * Constructs a new exception with the specified error code, detail message and cause.
+     *
+     * @param errorCode The error code.
+     * @param message   The detail message.
+     * @param cause     The cause.
+     */
+    public PublisherException(String errorCode, String message, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    /**
      * Constructs a new exception with the specified detail message.
      *
      * @param message The detail message.

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/http/HTTPPublisher.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/http/HTTPPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -39,7 +39,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import static org.wso2.carbon.identity.local.auth.smsotp.provider.constant.Constants.ErrorMessage.ERROR_UNAUTHORIZED_ACCESS;
+import static org.wso2.carbon.identity.local.auth.smsotp.provider.constant.Constants.ErrorMessage.UNAUTHORIZED;
 
 /**
  * This class will be used to publish the SMS to the custom SMS provider using the HTTP protocol.
@@ -120,15 +120,38 @@ public class HTTPPublisher {
                 log.debug("Successfully published the sms data to the: " + publisherURL);
                 log.debug("JSON data: " + json);
             }
-        } else if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+            return;
+        }
+
+        if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Unauthorized access while publishing the sms data to the: %s. " +
                         "Response code: %s.", publisherURL, responseCode));
             }
-            throw new PublisherException(ERROR_UNAUTHORIZED_ACCESS.getCode(),  ERROR_UNAUTHORIZED_ACCESS.getMessage());
-        } else {
-            log.warn("Error occurred while publishing the sms data to the: " + publisherURL
+            throw new PublisherException(UNAUTHORIZED.getCode(), UNAUTHORIZED.getMessage());
+        }
+
+        log.warn("Error occurred while publishing the sms data to the: " + publisherURL
                     + ". Response code: " + responseCode);
+
+        if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
+            throw new PublisherException(Constants.ErrorMessage.BAD_REQUEST.getCode(),
+                    Constants.ErrorMessage.BAD_REQUEST.getMessage());
+        } else if (responseCode == HttpURLConnection.HTTP_FORBIDDEN) {
+            throw new PublisherException(Constants.ErrorMessage.FORBIDDEN.getCode(),
+                    Constants.ErrorMessage.FORBIDDEN.getMessage());
+        } else if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+            throw new PublisherException(Constants.ErrorMessage.SERVICE_UNREACHABLE.getCode(),
+                    Constants.ErrorMessage.SERVICE_UNREACHABLE.getMessage());
+        } else if (responseCode == 429) {
+            throw new PublisherException(Constants.ErrorMessage.TOO_MANY_REQUESTS.getCode(),
+                    Constants.ErrorMessage.TOO_MANY_REQUESTS.getMessage());
+        } else if (responseCode >= HttpURLConnection.HTTP_INTERNAL_ERROR) {
+            throw new PublisherException(Constants.ErrorMessage.SERVER_ERROR.getCode(),
+                    Constants.ErrorMessage.SERVER_ERROR.getMessage());
+        } else {
+            throw new PublisherException(Constants.ErrorMessage.SMS_SEND_FAILED.getCode(),
+                    Constants.ErrorMessage.SMS_SEND_FAILED.getMessage());
         }
     }
 
@@ -144,7 +167,8 @@ public class HTTPPublisher {
                 throw new PublisherException("Invalid protocol. Protocol should be either http or https.");
             }
         } catch (MalformedURLException e) {
-            throw new PublisherException("", e);
+            throw new PublisherException(Constants.ErrorMessage.INVALID_CONFIGURATION.getCode(),
+                    Constants.ErrorMessage.INVALID_CONFIGURATION.getMessage(), e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/CustomProvider.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/CustomProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -42,7 +42,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.wso2.carbon.identity.local.auth.smsotp.provider.constant.Constants.ErrorMessage.ERROR_UNAUTHORIZED_ACCESS;
+import static org.wso2.carbon.identity.local.auth.smsotp.provider.constant.Constants.ErrorMessage.UNAUTHORIZED;
 
 /**
  * Implementation for the custom SMS provider. This provider is used to send the SMS using the custom SMS gateway.
@@ -101,6 +101,8 @@ public class CustomProvider implements Provider {
             LOG.warn("Error occurred while sending SMS to "
                     + ProviderUtil.hashTelephoneNumber(smsData.getToNumber()) + " using custom provider."
                     + ". Error: " + errorText);
+            throw new ProviderException(Constants.ErrorMessage.SMS_SEND_FAILED.getCode(),
+                    Constants.ErrorMessage.SMS_SEND_FAILED.getMessage(), e);
         } catch (NotificationSenderManagementException e) {
             throw new ProviderException(
                     "Error occurred while building authentication header for the notification provider", e);
@@ -121,7 +123,7 @@ public class CustomProvider implements Provider {
                 publisher.publish(smsData, smsSenderDTO.getProviderURL());
                 return;
             } catch (PublisherException e) {
-                if (!ERROR_UNAUTHORIZED_ACCESS.getCode().equals(e.getErrorCode()) || attempt >= allowedAttempts) {
+                if (!UNAUTHORIZED.getCode().equals(e.getErrorCode()) || attempt >= allowedAttempts) {
                     throw e;
                 }
                 Header newAuthHeader = SMSNotificationProviderDataHolder.getInstance()

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/CustomProvider.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/CustomProvider.java
@@ -101,8 +101,14 @@ public class CustomProvider implements Provider {
             LOG.warn("Error occurred while sending SMS to "
                     + ProviderUtil.hashTelephoneNumber(smsData.getToNumber()) + " using custom provider."
                     + ". Error: " + errorText);
-            throw new ProviderException(Constants.ErrorMessage.SMS_SEND_FAILED.getCode(),
+            String errorCode = e.getErrorCode();
+            String errorMessage = e.getMessage();
+            if (StringUtils.isNotBlank(errorCode) && StringUtils.isNotBlank(errorMessage)) {
+                throw new ProviderException(errorCode, errorMessage, e);
+            } else {
+                throw new ProviderException(Constants.ErrorMessage.SMS_SEND_FAILED.getCode(),
                     Constants.ErrorMessage.SMS_SEND_FAILED.getMessage(), e);
+            }
         } catch (NotificationSenderManagementException e) {
             throw new ProviderException(
                     "Error occurred while building authentication header for the notification provider", e);

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/TwilioProvider.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/TwilioProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -72,6 +72,7 @@ public class TwilioProvider implements Provider {
 
             if (message.getStatus() == Message.Status.FAILED) {
                 Message.Status status = message.getStatus();
+                Integer errorCode = message.getErrorCode();
                 String errorText = message.getErrorMessage();
 
                 ProviderUtil.triggerDiagnosticLogEvent(
@@ -80,6 +81,8 @@ public class TwilioProvider implements Provider {
                 LOG.warn("Error occurred while sending SMS to "
                         + ProviderUtil.hashTelephoneNumber(smsData.getToNumber()) + " using Twilio."
                         + " Status: " + status + ". Error: " + errorText);
+                Constants.ErrorMessage error = resolveTwilioMessageError(errorCode);
+                throw new ProviderException(error.getCode(), error.getMessage());
             } else if (LOG.isDebugEnabled()) {
                 LOG.debug("SMS sent to " + ProviderUtil.hashTelephoneNumber(smsData.getToNumber())
                         + " using Twilio." + " Status: " + message.getStatus());
@@ -94,10 +97,56 @@ public class TwilioProvider implements Provider {
             LOG.warn("Error occurred while sending SMS to "
                     + ProviderUtil.hashTelephoneNumber(smsData.getToNumber()) + " using Twilio."
                     + " Status: " + e.getStatusCode() + ". Error: " + errorText);
+            Constants.ErrorMessage error = resolveTwilioApiError(status);
+            throw new ProviderException(error.getCode(), error.getMessage(), e);
         } catch (Exception e) {
             throw new ProviderException("Error occurred while sending SMS to "
                     + ProviderUtil.hashTelephoneNumber(smsData.getToNumber())
                     + " using Twilio", e);
+        }
+    }
+
+    private Constants.ErrorMessage resolveTwilioMessageError(Integer twilioErrorCode) {
+
+        if (twilioErrorCode == null) {
+            return Constants.ErrorMessage.MESSAGE_DELIVERY_FAILED;
+        }
+        switch (twilioErrorCode) {
+            case 30001:
+                return Constants.ErrorMessage.TOO_MANY_REQUESTS;
+            case 30002:
+                return Constants.ErrorMessage.ACCOUNT_SUSPENDED;
+            case 30003:
+            case 30005:
+            case 30006:
+                return Constants.ErrorMessage.UNDELIVERABLE_NUMBER;
+            case 30004:
+            case 30007:
+                return Constants.ErrorMessage.CARRIER_FILTERED;
+            default:
+                return Constants.ErrorMessage.MESSAGE_DELIVERY_FAILED;
+        }
+    }
+
+    private Constants.ErrorMessage resolveTwilioApiError(Integer httpStatus) {
+
+        if (httpStatus == null) {
+            return Constants.ErrorMessage.SMS_SEND_FAILED;
+        }
+        if (httpStatus >= 500) {
+            return Constants.ErrorMessage.SERVER_ERROR;
+        }
+        switch (httpStatus) {
+            case 400:
+                return Constants.ErrorMessage.BAD_REQUEST;
+            case 401:
+                return Constants.ErrorMessage.UNAUTHORIZED;
+            case 403:
+                return Constants.ErrorMessage.FORBIDDEN;
+            case 429:
+                return Constants.ErrorMessage.TOO_MANY_REQUESTS;
+            default:
+                return Constants.ErrorMessage.SMS_SEND_FAILED;
         }
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/VonageProvider.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/VonageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -81,14 +81,44 @@ public class VonageProvider implements Provider {
                 LOG.warn("Error occurred while sending SMS to "
                         + ProviderUtil.hashTelephoneNumber(smsData.getToNumber()) + " using Vonage."
                         + " Status: " + response.getMessages().get(0).getStatus() + ". Error: " + errorText);
+                Constants.ErrorMessage error = resolveVonageError(status);
+                throw new ProviderException(error.getCode(), error.getMessage());
             } else if (LOG.isDebugEnabled()) {
                 LOG.debug("SMS sent to " + ProviderUtil.hashTelephoneNumber(smsData.getToNumber())
                         + " using Vonage");
             }
+        } catch (ProviderException e) {
+            throw e;
         } catch (Throwable throwable) {
             throw new ProviderException("Error occurred while sending SMS to "
                     + ProviderUtil.hashTelephoneNumber(smsData.getToNumber())
                     + " using Vonage", throwable);
+        }
+    }
+
+    private Constants.ErrorMessage resolveVonageError(MessageStatus status) {
+
+        if (status == null) {
+            return Constants.ErrorMessage.MESSAGE_DELIVERY_FAILED;
+        }
+        switch (status) {
+            case THROTTLED:
+                return Constants.ErrorMessage.TOO_MANY_REQUESTS;
+            case INVALID_CREDENTIALS:
+                return Constants.ErrorMessage.UNAUTHORIZED;
+            case INTERNAL_ERROR:
+                return Constants.ErrorMessage.SERVER_ERROR;
+            case PARTNER_QUOTA_EXCEEDED:
+                return Constants.ErrorMessage.ACCOUNT_LIMIT_EXCEEDED;
+            case NUMBER_BARRED:
+                return Constants.ErrorMessage.NUMBER_BARRED;
+            case MISSING_PARAMS:
+            case INVALID_PARAMS:
+                return Constants.ErrorMessage.INVALID_CONFIGURATION;
+            case PARTNER_ACCOUNT_BARRED:
+                return Constants.ErrorMessage.ACCOUNT_SUSPENDED;
+            default:
+                return Constants.ErrorMessage.MESSAGE_DELIVERY_FAILED;
         }
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/VonageProvider.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/VonageProvider.java
@@ -88,6 +88,7 @@ public class VonageProvider implements Provider {
                         + " using Vonage");
             }
         } catch (ProviderException e) {
+            // Re-throw without wrapping so the structured SP- error code is preserved for the caller.
             throw e;
         } catch (Throwable throwable) {
             throw new ProviderException("Error occurred while sending SMS to "

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/http/HTTPPublisherTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/http/HTTPPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,26 @@
 
 package org.wso2.carbon.identity.local.auth.smsotp.provider.http;
 
+import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.local.auth.smsotp.provider.constant.Constants;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.exception.PublisherException;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.model.SMSData;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.HttpURLConnection;
+
+import static org.mockito.Mockito.when;
 
 public class HTTPPublisherTest {
 
     private HTTPPublisher httpPublisher;
+    private static final String PUBLISHER_URL = "https://localhost:8888";
 
     @BeforeTest
     public void setUp() {
@@ -44,5 +56,72 @@ public class HTTPPublisherTest {
 
         SMSData smsData = new SMSData();
         httpPublisher.publish(smsData, "https://localhost:8888");
+    }
+
+    @DataProvider(name = "errorResponseCodes")
+    public Object[][] errorResponseCodes() {
+
+        return new Object[][] {
+            {HttpURLConnection.HTTP_UNAUTHORIZED, Constants.ErrorMessage.UNAUTHORIZED.getCode()},
+            {HttpURLConnection.HTTP_BAD_REQUEST,  Constants.ErrorMessage.BAD_REQUEST.getCode()},
+            {HttpURLConnection.HTTP_FORBIDDEN,    Constants.ErrorMessage.FORBIDDEN.getCode()},
+            {HttpURLConnection.HTTP_NOT_FOUND,    Constants.ErrorMessage.SERVICE_UNREACHABLE.getCode()},
+            {429,                                 Constants.ErrorMessage.TOO_MANY_REQUESTS.getCode()},
+            {HttpURLConnection.HTTP_INTERNAL_ERROR, Constants.ErrorMessage.SERVER_ERROR.getCode()},
+            {503,                                 Constants.ErrorMessage.SERVER_ERROR.getCode()},
+            {409,                                 Constants.ErrorMessage.SMS_SEND_FAILED.getCode()},
+        };
+    }
+
+    @Test(dataProvider = "errorResponseCodes")
+    public void testPublishThrowsCorrectErrorCodeForResponseCode(int responseCode, String expectedErrorCode)
+            throws Exception {
+
+        HttpURLConnection mockConnection = Mockito.mock(HttpURLConnection.class);
+        when(mockConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+        when(mockConnection.getResponseCode()).thenReturn(responseCode);
+
+        Method method = HTTPPublisher.class.getDeclaredMethod(
+                "publish", String.class, String.class, HttpURLConnection.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(httpPublisher, "{}", PUBLISHER_URL, mockConnection);
+            Assert.fail("Expected PublisherException for HTTP " + responseCode);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            Assert.assertTrue(cause instanceof PublisherException,
+                    "Expected PublisherException but got: " + cause.getClass().getName());
+            Assert.assertEquals(((PublisherException) cause).getErrorCode(), expectedErrorCode,
+                    "Wrong error code for HTTP " + responseCode);
+        }
+    }
+
+    @Test
+    public void testPublishSucceedsOnHttpOk() throws Exception {
+
+        HttpURLConnection mockConnection = Mockito.mock(HttpURLConnection.class);
+        when(mockConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+        when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        Method method = HTTPPublisher.class.getDeclaredMethod(
+                "publish", String.class, String.class, HttpURLConnection.class);
+        method.setAccessible(true);
+
+        method.invoke(httpPublisher, "{}", PUBLISHER_URL, mockConnection);
+    }
+
+    @Test
+    public void testPublishSucceedsOnHttpAccepted() throws Exception {
+
+        HttpURLConnection mockConnection = Mockito.mock(HttpURLConnection.class);
+        when(mockConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+        when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_ACCEPTED);
+
+        Method method = HTTPPublisher.class.getDeclaredMethod(
+                "publish", String.class, String.class, HttpURLConnection.class);
+        method.setAccessible(true);
+
+        method.invoke(httpPublisher, "{}", PUBLISHER_URL, mockConnection);
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/CustomProviderTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/CustomProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -280,8 +280,8 @@ public class CustomProviderTest {
         // Mock HTTPPublisher to throw unauthorized error on first attempt, then continue failing
         try (MockedConstruction<HTTPPublisher> mockedPublisher = mockConstruction(HTTPPublisher.class,
                 (mock, context) -> doThrow(new PublisherException(
-                        Constants.ErrorMessage.ERROR_UNAUTHORIZED_ACCESS.getCode(),
-                        Constants.ErrorMessage.ERROR_UNAUTHORIZED_ACCESS.getMessage()))
+                        Constants.ErrorMessage.UNAUTHORIZED.getCode(),
+                        Constants.ErrorMessage.UNAUTHORIZED.getMessage()))
                         .when(mock).publish(smsData, "https://localhost:8888"));
              MockedStatic<SMSNotificationProviderDataHolder> mockedDataHolder = 
                 mockStatic(SMSNotificationProviderDataHolder.class)) {

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/CustomProviderTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/CustomProviderTest.java
@@ -157,7 +157,7 @@ public class CustomProviderTest {
         try {
             customProvider.send(smsData, smsSenderDTO, "carbon.super");
         } catch (ProviderException e) {
-            Assert.assertEquals(e.getMessage(), "Error occurred while publishing the SMS data to the custom provider");
+            Assert.assertEquals(e.getMessage(), Constants.ErrorMessage.SMS_SEND_FAILED.getMessage());
         }
     }
 
@@ -214,7 +214,7 @@ public class CustomProviderTest {
             customProvider.send(smsData, smsSenderDTO, "carbon.super");
             Assert.assertEquals(smsData.getHeaders().get("authorization"), "Bearer test-token-value");
         } catch (ProviderException e) {
-            Assert.assertEquals(e.getMessage(), "Error occurred while publishing the SMS data to the custom provider");
+            Assert.assertEquals(e.getMessage(), Constants.ErrorMessage.SMS_SEND_FAILED.getMessage());
         }
     }
 
@@ -310,6 +310,59 @@ public class CustomProviderTest {
     }
 
     @Test
+    public void testSendPropagatesPublisherExceptionErrorCodeAndMessage() {
+
+        when(smsSenderDTO.getProviderURL()).thenReturn("https://localhost:8888");
+        when(smsSenderDTO.getSender()).thenReturn("sender");
+        when(smsSenderDTO.getContentType()).thenReturn("contentType");
+        when(smsSenderDTO.getProperties()).thenReturn(propertiesMap);
+        when(smsSenderDTO.getAuthentication()).thenReturn(null);
+
+        SMSData smsData = new SMSData();
+        smsData.setToNumber(TO_NUMBER);
+
+        String specificErrorCode = Constants.ErrorMessage.FORBIDDEN.getCode();
+        String specificErrorMessage = Constants.ErrorMessage.FORBIDDEN.getMessage();
+
+        try (MockedConstruction<HTTPPublisher> ignored = mockConstruction(HTTPPublisher.class,
+                (mock, context) -> doThrow(new PublisherException(specificErrorCode, specificErrorMessage))
+                        .when(mock).publish(Mockito.any(SMSData.class), Mockito.anyString()))) {
+            try {
+                customProvider.send(smsData, smsSenderDTO, "carbon.super");
+                Assert.fail("Expected ProviderException to be thrown");
+            } catch (ProviderException e) {
+                Assert.assertEquals(e.getErrorCode(), specificErrorCode);
+                Assert.assertEquals(e.getMessage(), specificErrorMessage);
+            }
+        }
+    }
+
+    @Test
+    public void testSendFallsBackToDefaultErrorWhenPublisherExceptionLacksErrorCode() {
+
+        when(smsSenderDTO.getProviderURL()).thenReturn("https://localhost:8888");
+        when(smsSenderDTO.getSender()).thenReturn("sender");
+        when(smsSenderDTO.getContentType()).thenReturn("contentType");
+        when(smsSenderDTO.getProperties()).thenReturn(propertiesMap);
+        when(smsSenderDTO.getAuthentication()).thenReturn(null);
+
+        SMSData smsData = new SMSData();
+        smsData.setToNumber(TO_NUMBER);
+
+        try (MockedConstruction<HTTPPublisher> ignored = mockConstruction(HTTPPublisher.class,
+                (mock, context) -> doThrow(new PublisherException("SMS send failed"))
+                        .when(mock).publish(Mockito.any(SMSData.class), Mockito.anyString()))) {
+            try {
+                customProvider.send(smsData, smsSenderDTO, "carbon.super");
+                Assert.fail("Expected ProviderException to be thrown");
+            } catch (ProviderException e) {
+                Assert.assertEquals(e.getErrorCode(), Constants.ErrorMessage.SMS_SEND_FAILED.getCode());
+                Assert.assertEquals(e.getMessage(), Constants.ErrorMessage.SMS_SEND_FAILED.getMessage());
+            }
+        }
+    }
+
+    @Test
     public void testSendWithApiKeyAuthAndNullAuthHeader() throws NotificationSenderManagementException {
 
         Map<String, String> authProperties = new HashMap<>();
@@ -343,8 +396,7 @@ public class CustomProviderTest {
                 customProvider.send(smsData, smsSenderDTO, "carbon.super");
             } catch (ProviderException e) {
                 // Expected to fail at publish since no auth header is set
-                Assert.assertEquals(e.getMessage(),
-                        "Error occurred while publishing the SMS data to the custom provider");
+                Assert.assertEquals(e.getMessage(), Constants.ErrorMessage.SMS_SEND_FAILED.getMessage());
             }
 
             // Verify that rebuildAuthHeaderWithNewToken was NOT called for API_KEY auth

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/TwilioProviderTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/TwilioProviderTest.java
@@ -18,6 +18,10 @@
 
 package org.wso2.carbon.identity.local.auth.smsotp.provider.impl;
 
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.rest.api.v2010.account.MessageCreator;
+import com.twilio.type.PhoneNumber;
 import io.jsonwebtoken.lang.Assert;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -36,6 +40,8 @@ import org.wso2.carbon.identity.notification.sender.tenant.config.dto.SMSSenderD
 
 import java.lang.reflect.Method;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -101,7 +107,18 @@ public class TwilioProviderTest {
         SMSData smsData = new SMSData();
         smsData.setToNumber("1234567890");
 
-        twilioProvider.send(smsData, smsSenderDTO, "carbon.super");
+        MessageCreator mockCreator = Mockito.mock(MessageCreator.class);
+        Message mockMessage = Mockito.mock(Message.class);
+        when(mockMessage.getStatus()).thenReturn(Message.Status.SENT);
+        when(mockCreator.create()).thenReturn(mockMessage);
+
+        try (MockedStatic<Twilio> mockedTwilio = mockStatic(Twilio.class);
+             MockedStatic<Message> mockedMessage = mockStatic(Message.class)) {
+            mockedMessage.when(() -> Message.creator(any(PhoneNumber.class), any(PhoneNumber.class),
+                            nullable(String.class)))
+                    .thenReturn(mockCreator);
+            twilioProvider.send(smsData, smsSenderDTO, "carbon.super");
+        }
     }
 
     @Test
@@ -116,7 +133,18 @@ public class TwilioProviderTest {
         SMSData smsData = new SMSData();
         smsData.setToNumber("1234567890");
 
-        twilioProvider.send(smsData, smsSenderDTO, "carbon.super");
+        MessageCreator mockCreator = Mockito.mock(MessageCreator.class);
+        Message mockMessage = Mockito.mock(Message.class);
+        when(mockMessage.getStatus()).thenReturn(Message.Status.SENT);
+        when(mockCreator.create()).thenReturn(mockMessage);
+
+        try (MockedStatic<Twilio> mockedTwilio = mockStatic(Twilio.class);
+             MockedStatic<Message> mockedMessage = mockStatic(Message.class)) {
+            mockedMessage.when(() -> Message.creator(any(PhoneNumber.class), any(PhoneNumber.class),
+                            nullable(String.class)))
+                    .thenReturn(mockCreator);
+            twilioProvider.send(smsData, smsSenderDTO, "carbon.super");
+        }
     }
 
     @DataProvider(name = "twilioMessageErrorCodes")

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/TwilioProviderTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/TwilioProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,15 +25,20 @@ import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.local.auth.smsotp.provider.constant.Constants;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.exception.ProviderException;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.exception.PublisherException;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.model.SMSData;
 import org.wso2.carbon.identity.notification.sender.tenant.config.dto.SMSSenderDTO;
 
+import java.lang.reflect.Method;
+
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 public class TwilioProviderTest {
 
@@ -112,5 +117,59 @@ public class TwilioProviderTest {
         smsData.setToNumber("1234567890");
 
         twilioProvider.send(smsData, smsSenderDTO, "carbon.super");
+    }
+
+    @DataProvider(name = "twilioMessageErrorCodes")
+    public Object[][] twilioMessageErrorCodes() {
+
+        return new Object[][]{
+                {null, Constants.ErrorMessage.MESSAGE_DELIVERY_FAILED},
+                {30001, Constants.ErrorMessage.TOO_MANY_REQUESTS},
+                {30002, Constants.ErrorMessage.ACCOUNT_SUSPENDED},
+                {30003, Constants.ErrorMessage.UNDELIVERABLE_NUMBER},
+                {30004, Constants.ErrorMessage.CARRIER_FILTERED},
+                {30005, Constants.ErrorMessage.UNDELIVERABLE_NUMBER},
+                {30006, Constants.ErrorMessage.UNDELIVERABLE_NUMBER},
+                {30007, Constants.ErrorMessage.CARRIER_FILTERED},
+                {99999, Constants.ErrorMessage.MESSAGE_DELIVERY_FAILED},
+        };
+    }
+
+    @Test(dataProvider = "twilioMessageErrorCodes")
+    public void testResolveTwilioMessageError(Integer twilioErrorCode, Constants.ErrorMessage expected)
+            throws Exception {
+
+        Method method = TwilioProvider.class.getDeclaredMethod("resolveTwilioMessageError", Integer.class);
+        method.setAccessible(true);
+
+        Constants.ErrorMessage result = (Constants.ErrorMessage) method.invoke(twilioProvider, twilioErrorCode);
+        assertEquals(result, expected,
+                "resolveTwilioMessageError(" + twilioErrorCode + ") should return " + expected);
+    }
+
+    @DataProvider(name = "twilioApiErrorCodes")
+    public Object[][] twilioApiErrorCodes() {
+
+        return new Object[][]{
+                {null, Constants.ErrorMessage.SMS_SEND_FAILED},
+                {400, Constants.ErrorMessage.BAD_REQUEST},
+                {401, Constants.ErrorMessage.UNAUTHORIZED},
+                {403, Constants.ErrorMessage.FORBIDDEN},
+                {429, Constants.ErrorMessage.TOO_MANY_REQUESTS},
+                {500, Constants.ErrorMessage.SERVER_ERROR},
+                {503, Constants.ErrorMessage.SERVER_ERROR},
+                {404, Constants.ErrorMessage.SMS_SEND_FAILED},
+        };
+    }
+
+    @Test(dataProvider = "twilioApiErrorCodes")
+    public void testResolveTwilioApiError(Integer httpStatus, Constants.ErrorMessage expected) throws Exception {
+
+        Method method = TwilioProvider.class.getDeclaredMethod("resolveTwilioApiError", Integer.class);
+        method.setAccessible(true);
+
+        Constants.ErrorMessage result = (Constants.ErrorMessage) method.invoke(twilioProvider, httpStatus);
+        assertEquals(result, expected,
+                "resolveTwilioApiError(" + httpStatus + ") should return " + expected);
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/VonageProviderTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/VonageProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.local.auth.smsotp.provider.impl;
 
+import com.vonage.client.sms.MessageStatus;
 import io.jsonwebtoken.lang.Assert;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -25,15 +26,20 @@ import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.local.auth.smsotp.provider.constant.Constants;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.exception.ProviderException;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.exception.PublisherException;
 import org.wso2.carbon.identity.local.auth.smsotp.provider.model.SMSData;
 import org.wso2.carbon.identity.notification.sender.tenant.config.dto.SMSSenderDTO;
 
+import java.lang.reflect.Method;
+
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 public class VonageProviderTest {
 
@@ -112,5 +118,33 @@ public class VonageProviderTest {
         smsData.setToNumber("1234567890");
 
         vonageProvider.send(smsData, smsSenderDTO, "carbon.super");
+    }
+
+    @DataProvider(name = "vonageErrorStatuses")
+    public Object[][] vonageErrorStatuses() {
+
+        return new Object[][]{
+                {null, Constants.ErrorMessage.MESSAGE_DELIVERY_FAILED},
+                {MessageStatus.THROTTLED, Constants.ErrorMessage.TOO_MANY_REQUESTS},
+                {MessageStatus.INVALID_CREDENTIALS, Constants.ErrorMessage.UNAUTHORIZED},
+                {MessageStatus.INTERNAL_ERROR, Constants.ErrorMessage.SERVER_ERROR},
+                {MessageStatus.PARTNER_QUOTA_EXCEEDED, Constants.ErrorMessage.ACCOUNT_LIMIT_EXCEEDED},
+                {MessageStatus.NUMBER_BARRED, Constants.ErrorMessage.NUMBER_BARRED},
+                {MessageStatus.MISSING_PARAMS, Constants.ErrorMessage.INVALID_CONFIGURATION},
+                {MessageStatus.INVALID_PARAMS, Constants.ErrorMessage.INVALID_CONFIGURATION},
+                {MessageStatus.PARTNER_ACCOUNT_BARRED, Constants.ErrorMessage.ACCOUNT_SUSPENDED},
+                {MessageStatus.UNKNOWN, Constants.ErrorMessage.MESSAGE_DELIVERY_FAILED},
+        };
+    }
+
+    @Test(dataProvider = "vonageErrorStatuses")
+    public void testResolveVonageError(MessageStatus status, Constants.ErrorMessage expected) throws Exception {
+
+        Method method = VonageProvider.class.getDeclaredMethod("resolveVonageError", MessageStatus.class);
+        method.setAccessible(true);
+
+        Constants.ErrorMessage result = (Constants.ErrorMessage) method.invoke(vonageProvider, status);
+        assertEquals(result, expected,
+                "resolveVonageError(" + status + ") should return " + expected);
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/VonageProviderTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.provider/src/test/java/org/wso2/carbon/identity/local/auth/smsotp/provider/impl/VonageProviderTest.java
@@ -18,9 +18,14 @@
 
 package org.wso2.carbon.identity.local.auth.smsotp.provider.impl;
 
+import com.vonage.client.VonageClient;
 import com.vonage.client.sms.MessageStatus;
+import com.vonage.client.sms.SmsClient;
+import com.vonage.client.sms.SmsSubmissionResponse;
+import com.vonage.client.sms.SmsSubmissionResponseMessage;
 import io.jsonwebtoken.lang.Assert;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
@@ -36,7 +41,11 @@ import org.wso2.carbon.identity.local.auth.smsotp.provider.model.SMSData;
 import org.wso2.carbon.identity.notification.sender.tenant.config.dto.SMSSenderDTO;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -90,7 +99,7 @@ public class VonageProviderTest {
         vonageProvider.send(smsData, smsSenderDTO, "carbon.super");
     }
 
-    @Test()
+    @Test
     public void testInitSuccess() throws ProviderException {
 
         when(smsSenderDTO.getProviderURL()).thenReturn("http://localhost:8080");
@@ -102,10 +111,26 @@ public class VonageProviderTest {
         SMSData smsData = new SMSData();
         smsData.setToNumber("1234567890");
 
-        vonageProvider.send(smsData, smsSenderDTO, "carbon.super");
+        VonageClient mockClient = Mockito.mock(VonageClient.class);
+        SmsClient mockSmsClient = Mockito.mock(SmsClient.class);
+        SmsSubmissionResponse mockResponse = Mockito.mock(SmsSubmissionResponse.class);
+        SmsSubmissionResponseMessage mockSmsMessage = Mockito.mock(SmsSubmissionResponseMessage.class);
+        when(mockSmsMessage.getStatus()).thenReturn(MessageStatus.OK);
+        when(mockResponse.getMessages()).thenReturn(Arrays.asList(mockSmsMessage));
+        when(mockSmsClient.submitMessage(any())).thenReturn(mockResponse);
+        when(mockClient.getSmsClient()).thenReturn(mockSmsClient);
+
+        try (MockedConstruction<VonageClient.Builder> mockedBuilder = mockConstruction(VonageClient.Builder.class,
+                (mock, context) -> {
+                    when(mock.apiKey(anyString())).thenReturn(mock);
+                    when(mock.apiSecret(anyString())).thenReturn(mock);
+                    when(mock.build()).thenReturn(mockClient);
+                })) {
+            vonageProvider.send(smsData, smsSenderDTO, "carbon.super");
+        }
     }
 
-    @Test()
+    @Test
     public void testSend() throws ProviderException {
 
         when(smsSenderDTO.getProviderURL()).thenReturn("http://localhost:8080");
@@ -117,7 +142,23 @@ public class VonageProviderTest {
         SMSData smsData = new SMSData();
         smsData.setToNumber("1234567890");
 
-        vonageProvider.send(smsData, smsSenderDTO, "carbon.super");
+        VonageClient mockClient = Mockito.mock(VonageClient.class);
+        SmsClient mockSmsClient = Mockito.mock(SmsClient.class);
+        SmsSubmissionResponse mockResponse = Mockito.mock(SmsSubmissionResponse.class);
+        SmsSubmissionResponseMessage mockSmsMessage = Mockito.mock(SmsSubmissionResponseMessage.class);
+        when(mockSmsMessage.getStatus()).thenReturn(MessageStatus.OK);
+        when(mockResponse.getMessages()).thenReturn(Arrays.asList(mockSmsMessage));
+        when(mockSmsClient.submitMessage(any())).thenReturn(mockResponse);
+        when(mockClient.getSmsClient()).thenReturn(mockSmsClient);
+
+        try (MockedConstruction<VonageClient.Builder> mockedBuilder = mockConstruction(VonageClient.Builder.class,
+                (mock, context) -> {
+                    when(mock.apiKey(anyString())).thenReturn(mock);
+                    when(mock.apiSecret(anyString())).thenReturn(mock);
+                    when(mock.build()).thenReturn(mockClient);
+                })) {
+            vonageProvider.send(smsData, smsSenderDTO, "carbon.super");
+        }
     }
 
     @DataProvider(name = "vonageErrorStatuses")

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <identity.governance.version>1.11.126</identity.governance.version>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <carbon.identity.account.lock.handler.version>1.8.2</carbon.identity.account.lock.handler.version>
-        <identity.auth.otp.commons.version>1.1.1</identity.auth.otp.commons.version>
+        <identity.auth.otp.commons.version>1.1.6-SNAPSHOT</identity.auth.otp.commons.version>
         <identity.event.handler.notification.version>1.9.75</identity.event.handler.notification.version>
         <identity.notification.sender.tenant.config.version>1.9.75</identity.notification.sender.tenant.config.version>
         <identity.organization.management.core.version>1.0.93</identity.organization.management.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <identity.governance.version>1.11.126</identity.governance.version>
         <identity.extension.utils>1.0.12</identity.extension.utils>
         <carbon.identity.account.lock.handler.version>1.8.2</carbon.identity.account.lock.handler.version>
-        <identity.auth.otp.commons.version>1.1.6-SNAPSHOT</identity.auth.otp.commons.version>
+        <identity.auth.otp.commons.version>1.1.6</identity.auth.otp.commons.version>
         <identity.event.handler.notification.version>1.9.75</identity.event.handler.notification.version>
         <identity.notification.sender.tenant.config.version>1.9.75</identity.notification.sender.tenant.config.version>
         <identity.organization.management.core.version>1.0.93</identity.organization.management.core.version>


### PR DESCRIPTION
## Purpose

This PR introduces opt-in support for surfacing SMS provider failure details to users and clients during SMS OTP authentication. When enabled via a new connector config, structured provider error codes (prefixed with `SP-`) are propagated from the SMS provider layer through the event handler and authenticator, and included in the OTP page redirect URL so the UI can display provider-specific failure messages.

### Changes

**New configuration property**
Added `SmsOTP.NotifySmsSendingFailure` (default: `false`) as a new connector config property. When set to `true`, provider-specific failure details are surfaced instead of being swallowed as generic authentication errors.

**Structured error codes for SMS providers**
Introduced a set of standardized `SP-` prefixed error codes in the provider layer:
- `SP-60001` — Unauthorized (authentication with SMS service failed)
- `SP-60002` — Forbidden (account lacks required permissions)
- `SP-60003` — Bad request (SMS service rejected the request)
- `SP-60004` — Too many requests (SMS service rate limit exceeded)
- `SP-60005` — Server error (SMS provider internal error)

**Provider-level error propagation**
- `HTTPPublisher` now maps HTTP response codes (401, 403, 400, 429, 5xx) to structured `SP-` error codes thrown via `PublisherException`.
- Twilio and Vonage providers map their native error codes to the standardized `SP-` codes and throw `ProviderException` with the appropriate code and user-facing message.
- Custom provider now throws `ProviderException` on publish failure instead of only logging.

**Event handler**
`SMSNotificationHandler` re-throws provider failures as `IdentityEventException` carrying the `SP-` error code when the `notifySpecificProviderFailures` flag is present in the event properties.

**Authenticator**
When notification is enabled and a `SP-` prefixed error arrives via `IdentityEventException`, the error is captured as an `AuthenticatorMessage` on the context rather than failing authentication outright. The new `getOTPPageRedirectErrorCode()` override passes this error code in the OTP page redirect URL, enabling the UI to display provider-specific failure information.

## Related Issue
- https://github.com/wso2/product-is/issues/28017