### PR TITLE
Add device registration flow support to the SMS OTP executor

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/SMSOTPExecutor.java
@@ -48,6 +48,7 @@ import static org.wso2.carbon.identity.local.auth.smsotp.authenticator.constant.
 public class SMSOTPExecutor extends AbstractOTPExecutor {
 
     private static final String REGISTRATION = "REGISTRATION";
+    private static final String DEVICE_REGISTRATION = "DEVICE_REGISTRATION";
 
     @Override
     public String getName() {
@@ -177,6 +178,8 @@ public class SMSOTPExecutor extends AbstractOTPExecutor {
         switch (flowExecutionContext.getFlowType()) {
             case REGISTRATION:
                 return SMS_OTP_VERIFICATION_TEMPLATE;
+            case DEVICE_REGISTRATION:
+                return SMSOTPConstants.SMS_OTP_DEVICE_REGISTRATION_TEMPLATE;
             default:
                 return PASSWORD_RESET_TEMPLATE;
         }

--- a/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.smsotp.authenticator/src/main/java/org/wso2/carbon/identity/local/auth/smsotp/authenticator/constant/SMSOTPConstants.java
@@ -44,6 +44,7 @@ public class SMSOTPConstants {
     public static final String DISPLAY_USERNAME = "Username";
     public static final String PASSWORD = "password";
     public static final String SMS_OTP_VERIFICATION_TEMPLATE = "SMSOTPVerification";
+    public static final String SMS_OTP_DEVICE_REGISTRATION_TEMPLATE = "SMSOTPDeviceRegistration";
     public static final String PASSWORD_RESET_TEMPLATE = "passwordReset";
     public static final String SMS_TEMPLATE_TYPE = "notificationTemplate";
     public static final String SMS_OTP_RETRY_ATTEMPTS_PROPERTY_NAME = "smsOtpRetryAttempts";


### PR DESCRIPTION
## Proposed changes in this pull request

Adds two constants to `SMSOTPExecutor`, `DEVICE_REGISTRATION` and the dedicated `SMSOTPDeviceRegistration` template type, and maps them together in `resolveOTPTemplate(...)`.


### Usage

In device registration flow

### Testing

N/A

## When should this PR be merged

This change depends on the `DEVICE_REGISTRATION` flow type being available in `org.wso2.carbon.identity.flow.mgt`, 

## Follow up actions

N/A
